### PR TITLE
Feature/16/examples refactoring

### DIFF
--- a/aiida_sssp_workflow/workflows/bands.py
+++ b/aiida_sssp_workflow/workflows/bands.py
@@ -213,7 +213,7 @@ class BandsWorkChain(WorkChain):
         fermi_energy = workchain.outputs.band_parameters['fermi_energy']
         bands = workchain.outputs.band_structure.get_array(
             'bands') - fermi_energy
-        eigv = np.amin(bands[:, -1])
+        eigv = float(np.amin(bands[:, -1]))
         self.ctx.lowest_highest_eigenvalue = eigv
 
         self.ctx.nbands_factor += 1.0

--- a/aiida_sssp_workflow/workflows/bands.py
+++ b/aiida_sssp_workflow/workflows/bands.py
@@ -161,10 +161,14 @@ class BandsWorkChain(WorkChain):
             'structure': self.inputs.structure,
             'scf': {
                 'pw': {
-                    'code': self.inputs.code,
-                    'pseudos': self.ctx.pseudos,
-                    'parameters': self.ctx.pw_scf_parameters,
-                    'settings': orm.Dict(dict={'CMDLINE': ['-ndiag', '1']}),
+                    'code':
+                    self.inputs.code,
+                    'pseudos':
+                    self.ctx.pseudos,
+                    'parameters':
+                    self.ctx.pw_scf_parameters,
+                    'settings':
+                    orm.Dict(dict={'CMDLINE': ['-ndiag', '1', '-nk', '4']}),
                     'metadata': {
                         'options': options
                     },

--- a/aiida_sssp_workflow/workflows/bands.py
+++ b/aiida_sssp_workflow/workflows/bands.py
@@ -99,7 +99,7 @@ class BandsWorkChain(WorkChain):
         # TODO set ecutwfc and ecutrho according to certain protocol
         scf_parameters = {
             'SYSTEM': {
-                'degauss': 0.02,
+                'degauss': 0.00735,
                 'occupations': 'smearing',
                 'smearing': 'marzari-vanderbilt',
             },

--- a/aiida_sssp_workflow/workflows/bands.py
+++ b/aiida_sssp_workflow/workflows/bands.py
@@ -202,7 +202,8 @@ class BandsWorkChain(WorkChain):
         fermi_energy = workchain.outputs.band_parameters['fermi_energy']
         bands = workchain.outputs.band_structure.get_array(
             'bands') - fermi_energy
-        self.ctx.lowest_highest_eigenvalue = np.amin(bands[:, -1])
+        eigv = np.amin(bands[:, -1])
+        self.ctx.lowest_highest_eigenvalue = eigv
 
         self.ctx.nbands_factor += 1.0
         self.ctx.output_nbands_factor = self.ctx.nbands_factor - 1.0

--- a/aiida_sssp_workflow/workflows/cohesive_energy.py
+++ b/aiida_sssp_workflow/workflows/cohesive_energy.py
@@ -177,7 +177,8 @@ class CohesiveEnergyWorkChain(WorkChain):
                 'code': self.inputs.code,
                 'pseudos': self.ctx.pseudos,
                 'parameters': orm.Dict(dict=self.ctx.pw_bulk_parameters),
-                'settings': orm.Dict(dict={'CMDLINE': ['-ndiag', '1']}),
+                'settings':
+                orm.Dict(dict={'CMDLINE': ['-ndiag', '1', '-nk', '4']}),
                 'metadata': {},
             },
             'kpoints_distance':

--- a/aiida_sssp_workflow/workflows/cohesive_energy.py
+++ b/aiida_sssp_workflow/workflows/cohesive_energy.py
@@ -43,6 +43,39 @@ PW_PARAS = lambda: orm.Dict(dict={
 
 class CohesiveEnergyWorkChain(WorkChain):
     """WorkChain to calculate cohisive energy of input structure"""
+
+    _BULK_PARAMETERS = {
+        'SYSTEM': {
+            'degauss': 0.02,
+            'occupations': 'smearing',
+            'smearing': 'marzari-vanderbilt',
+        },
+        'ELECTRONS': {
+            'conv_thr': 1e-10,
+        },
+        'CONTROL': {
+            'calculation': 'scf',
+            'wf_collect': True,
+            'tstress': True,
+        },
+    }
+
+    _ATOM_PARAMETERS = {
+        'SYSTEM': {
+            'degauss': 0.02,
+            'occupations': 'smearing',
+            'smearing': 'gaussian',
+        },
+        'ELECTRONS': {
+            'conv_thr': 1e-10,
+        },
+    }
+
+    _BULK_CMDLINE_SETTING = {'CMDLINE': ['-ndiag', '1', '-nk', '4']}
+    _ATOM_CMDLINE_SETTING = {
+        'CMDLINE': ['-ndiag', '1']
+    }  # TODO use the same one above
+
     @classmethod
     def define(cls, spec):
         super().define(spec)
@@ -110,31 +143,8 @@ class CohesiveEnergyWorkChain(WorkChain):
 
     def setup(self):
         """Input validation"""
-        bulk_parameters = {
-            'SYSTEM': {
-                'degauss': 0.02,
-                'occupations': 'smearing',
-                'smearing': 'marzari-vanderbilt',
-            },
-            'ELECTRONS': {
-                'conv_thr': 1e-10,
-            },
-            'CONTROL': {
-                'calculation': 'scf',
-                'wf_collect': True,
-                'tstress': True,
-            },
-        }
-        atom_parameters = {
-            'SYSTEM': {
-                'degauss': 0.02,
-                'occupations': 'smearing',
-                'smearing': 'gaussian',
-            },
-            'ELECTRONS': {
-                'conv_thr': 1e-10,
-            },
-        }
+        bulk_parameters = self._BULK_PARAMETERS
+        atom_parameters = self._ATOM_PARAMETERS
         pw_bulk_parameters = update_dict(
             bulk_parameters, self.inputs.parameters.pw_bulk.get_dict())
         pw_atom_parameters = update_dict(
@@ -177,8 +187,7 @@ class CohesiveEnergyWorkChain(WorkChain):
                 'code': self.inputs.code,
                 'pseudos': self.ctx.pseudos,
                 'parameters': orm.Dict(dict=self.ctx.pw_bulk_parameters),
-                'settings':
-                orm.Dict(dict={'CMDLINE': ['-ndiag', '1', '-nk', '4']}),
+                'settings': orm.Dict(dict=self._BULK_CMDLINE_SETTING),
                 'metadata': {},
             },
             'kpoints_distance':
@@ -227,7 +236,7 @@ class CohesiveEnergyWorkChain(WorkChain):
                         element: pseudo
                     },
                     'parameters': orm.Dict(dict=atom_pw_parameters),
-                    'settings': orm.Dict(dict={'CMDLINE': ['-ndiag', '1']}),
+                    'settings': orm.Dict(dict=self._ATOM_CMDLINE_SETTING),
                     'metadata': {},
                 },
                 'kpoints': atom_kpoints,

--- a/aiida_sssp_workflow/workflows/cohesive_energy.py
+++ b/aiida_sssp_workflow/workflows/cohesive_energy.py
@@ -119,6 +119,11 @@ class CohesiveEnergyWorkChain(WorkChain):
             'ELECTRONS': {
                 'conv_thr': 1e-10,
             },
+            'CONTROL': {
+                'calculation': 'scf',
+                'wf_collect': True,
+                'tstress': True,
+            },
         }
         atom_parameters = {
             'SYSTEM': {

--- a/aiida_sssp_workflow/workflows/cohesive_energy.py
+++ b/aiida_sssp_workflow/workflows/cohesive_energy.py
@@ -229,9 +229,9 @@ class CohesiveEnergyWorkChain(WorkChain):
             atom_inputs.pw.metadata.options = options
 
             # TODO following is mandatory for lanthanides, should be check again, whether needed for other elements.
-            if atom_inputs.pw.parameters['SYSTEM']['ecutwfc'] > 100.0:
+            if element in RARE_EARTH_ELEMENTS:
                 self.report(
-                    'Big cell in isolate atom calculation with large cuttoff require more RAM.'
+                    'Big cell in isolate lanthenides atom calculation with large cuttoff require more RAM.'
                 )
                 atom_inputs.pw.metadata.options['resources'][
                     'num_machines'] = 4

--- a/aiida_sssp_workflow/workflows/convergence/bands.py
+++ b/aiida_sssp_workflow/workflows/convergence/bands.py
@@ -29,6 +29,16 @@ PARA_ECUTRHO_LIST = lambda: orm.List(list=[
 
 class ConvergenceBandsWorkChain(WorkChain):
     """WorkChain to converge test on cohisive energy of input structure"""
+
+    _DEGUASS = 0.00735
+    _OCCUPATIONS = 'smearing'
+    _SMEARING = 'marzari-vanderbilt'
+    _CONV_THR = 1e-10
+    _SCF_KDISTANCE = 0.15
+    _BAND_KDISTANCE = 0.20
+
+    _RY_TO_EV = 13.6056980659
+
     @classmethod
     def define(cls, spec):
         super().define(spec)
@@ -146,14 +156,14 @@ class ConvergenceBandsWorkChain(WorkChain):
                    nbands_factor: orm.Float = orm.Float(2.0)):
         _PW_PARAS = {   # pylint: disable=invalid-name
             'SYSTEM': {
-                'degauss': 0.00735,
-                'occupations': 'smearing',
-                'smearing': 'marzari-vanderbilt',
+                'degauss': self._DEGUASS,
+                'occupations': self._OCCUPATIONS,
+                'smearing': self._SMEARING,
                 'ecutrho': ecutrho,
                 'ecutwfc': ecutwfc,
             },
             'ELECTRONS': {
-                'conv_thr': 1e-10,
+                'conv_thr': self._CONV_THR,
             },
         }
 
@@ -164,8 +174,8 @@ class ConvergenceBandsWorkChain(WorkChain):
             'parameters': {
                 'pw':
                 orm.Dict(dict=update_dict(_PW_PARAS, self.ctx.pw_parameters)),
-                'scf_kpoints_distance': orm.Float(0.15),
-                'bands_kpoints_distance': orm.Float(0.2),
+                'scf_kpoints_distance': orm.Float(self._SCF_KDISTANCE),
+                'bands_kpoints_distance': orm.Float(self._BAND_KDISTANCE),
                 'nbands_factor': nbands_factor,
             },
         })
@@ -225,8 +235,6 @@ class ConvergenceBandsWorkChain(WorkChain):
         from aiida_sssp_workflow.utils import NONMETAL_ELEMENTS
         from aiida_sssp_workflow.calculations.calculate_bands_distance import calculate_bands_distance
 
-        RY_TO_EV = 13.6056980659  # pylint: disable=invalid-name
-
         pks = [
             child.pk for child in self.ctx.children if not child.is_finished_ok
         ]
@@ -257,7 +265,7 @@ class ConvergenceBandsWorkChain(WorkChain):
             ecutwfc_list.append(ecutwfc)
             ecutrho_list.append(ecutrho)
 
-            smearing = orm.Float(0.00735 * RY_TO_EV)
+            smearing = orm.Float(0.00735 * self._RY_TO_EV)
             if self.inputs.pseudo.element in NONMETAL_ELEMENTS:
                 is_metal = orm.Bool(False)
             else:

--- a/aiida_sssp_workflow/workflows/convergence/cohesive_energy.py
+++ b/aiida_sssp_workflow/workflows/convergence/cohesive_energy.py
@@ -39,11 +39,6 @@ class ConvergenceCohesiveEnergyWorkChain(WorkChain):
                    valid_type=orm.UpfData,
                    required=True,
                    help='Pseudopotential to be verified')
-        spec.input('ref_cutoff_pair',
-                   valid_type=orm.List,
-                   required=True,
-                   default=lambda: orm.List(list=[200, 1600]),
-                   help='ecutwfc/ecutrho pair for reference calculation.')
         spec.input('options',
                    valid_type=orm.Dict,
                    required=False,

--- a/aiida_sssp_workflow/workflows/convergence/cohesive_energy.py
+++ b/aiida_sssp_workflow/workflows/convergence/cohesive_energy.py
@@ -29,6 +29,15 @@ PARA_ECUTRHO_LIST = lambda: orm.List(list=[
 
 class ConvergenceCohesiveEnergyWorkChain(WorkChain):
     """WorkChain to converge test on cohisive energy of input structure"""
+
+    _DEGUASS = 0.00735
+    _OCCUPATIONS = 'smearing'
+    _BULK_SMEARING = 'marzari-vanderbilt'
+    _ATOM_SMEARING = 'gaussian'
+    _CONV_THR = 1e-10
+    _KDISTANCE = 0.15
+    _VACUUM_LENGTH = 12.0
+
     @classmethod
     def define(cls, spec):
         super().define(spec)
@@ -147,20 +156,26 @@ class ConvergenceCohesiveEnergyWorkChain(WorkChain):
     def get_inputs(self, ecutwfc, ecutrho):
         _PW_BULK_PARAS = {   # pylint: disable=invalid-name
             'SYSTEM': {
-                'degauss': 0.00735,
-                'occupations': 'smearing',
-                'smearing': 'marzari-vanderbilt',
+                'degauss': self._DEGUASS,
+                'occupations': self._OCCUPATIONS,
+                'smearing': self._BULK_SMEARING,
                 'ecutrho': ecutrho,
                 'ecutwfc': ecutwfc,
+            },
+            'ELECTRONS': {
+                'conv_thr': self._CONV_THR,
             },
         }
         _PW_ATOM_PARAS = {   # pylint: disable=invalid-name
             'SYSTEM': {
-                'degauss': 0.00735,
-                'occupations': 'smearing',
-                'smearing': 'gaussian',
+                'degauss': self._DEGUASS,
+                'occupations': self._OCCUPATIONS,
+                'smearing': self._ATOM_SMEARING,
                 'ecutrho': ecutrho,
                 'ecutwfc': ecutwfc,
+            },
+            'ELECTRONS': {
+                'conv_thr': self._CONV_THR,
             },
         }
         inputs = AttributeDict({
@@ -174,9 +189,9 @@ class ConvergenceCohesiveEnergyWorkChain(WorkChain):
                 'pw_atom':
                 orm.Dict(dict=_PW_ATOM_PARAS),
                 'kpoints_distance':
-                orm.Float(0.15),
+                orm.Float(self._KDISTANCE),
                 'vacuum_length':
-                orm.Float(12.0),
+                orm.Float(self._VACUUM_LENGTH),
             },
         })
 

--- a/aiida_sssp_workflow/workflows/convergence/phonon_frequencies.py
+++ b/aiida_sssp_workflow/workflows/convergence/phonon_frequencies.py
@@ -83,6 +83,11 @@ class ConvergencePhononFrequenciesWorkChain(WorkChain):
                    valid_type=orm.List,
                    default=PARA_ECUTWFC_LIST,
                    help='list of ecutwfc evaluate list.')
+        spec.input('parameters.ref_cutoff_pair',
+                   valid_type=orm.List,
+                   required=True,
+                   default=lambda: orm.List(list=[200, 1600]),
+                   help='ecutwfc/ecutrho pair for reference calculation.')
         spec.outline(
             cls.setup,
             cls.validate_structure,
@@ -161,7 +166,7 @@ class ConvergencePhononFrequenciesWorkChain(WorkChain):
             # The Cif is already store let's return it
             cif_data = orm.CifData.get_or_create(filename)[0]
 
-        self.ctx.structure = cif_data.get_structure()
+        self.ctx.structure = cif_data.get_structure(primitive_cell=True)
         self.ctx.pseudos = pseudos
         self.ctx.pw_parameters = pw_parameters
 
@@ -206,8 +211,9 @@ class ConvergencePhononFrequenciesWorkChain(WorkChain):
         Running the calculation for the reference point
         hard code to 200Ry at the moment
         """
-        ecutwfc = 200
-        ecutrho = 1600
+        cutoff_pair = self.inputs.parameters.ref_cutoff_pair.get_list()
+        ecutwfc = cutoff_pair[0]
+        ecutrho = cutoff_pair[1]
         inputs = self.get_inputs(ecutwfc, ecutrho)
 
         running = self.submit(PhononFrequenciesWorkChain, **inputs)

--- a/aiida_sssp_workflow/workflows/convergence/phonon_frequencies.py
+++ b/aiida_sssp_workflow/workflows/convergence/phonon_frequencies.py
@@ -57,6 +57,20 @@ def helper_get_relative_phonon_frequencies(
 
 class ConvergencePhononFrequenciesWorkChain(WorkChain):
     """WorkChain to converge test on cohisive energy of input structure"""
+    _DEGUASS = 0.00735
+    _OCCUPATIONS = 'smearing'
+    _SMEARING = 'marzari-vanderbilt'
+    _CONV_THR = 1e-10
+    _QPOINTS_LIST = [[0.5, 0.5, 0.5]]
+    _KDISTANCE = 0.15
+
+    _PH_PARAMETERS = {
+        'INPUTPH': {
+            'tr2_ph': 1e-16,
+            'epsil': False,
+        }
+    }
+
     @classmethod
     def define(cls, spec):
         super().define(spec)
@@ -173,22 +187,17 @@ class ConvergencePhononFrequenciesWorkChain(WorkChain):
     def get_inputs(self, ecutwfc, ecutrho):
         _PW_PARAS = {   # pylint: disable=invalid-name
             'SYSTEM': {
-                'degauss': 0.00735,
-                'occupations': 'smearing',
-                'smearing': 'marzari-vanderbilt',
+                'degauss': self._DEGUASS,
+                'occupations': self._OCCUPATIONS,
+                'smearing': self._SMEARING,
                 'ecutrho': ecutrho,
                 'ecutwfc': ecutwfc,
             },
             'ELECTRONS': {
-                'conv_thr': 1e-10,
+                'conv_thr': self._CONV_THR,
             },
         }
-        _PH_PARAS = {  # pylint: disable=invalid-name
-            'INPUTPH': {
-                'tr2_ph': 1e-16,
-                'epsil': False,
-            }
-        }
+        _PH_PARAS = self._PH_PARAMETERS  # pylint: disable=invalid-name
 
         inputs = AttributeDict({
             'pw_code': self.inputs.pw_code,
@@ -199,8 +208,8 @@ class ConvergencePhononFrequenciesWorkChain(WorkChain):
                 'pw':
                 orm.Dict(dict=update_dict(_PW_PARAS, self.ctx.pw_parameters)),
                 'ph': orm.Dict(dict=_PH_PARAS),
-                'kpoints_distance': orm.Float(0.15),
-                'qpoints': orm.List(list=[[0.5, 0.5, 0.5]]),
+                'kpoints_distance': orm.Float(self._KDISTANCE),
+                'qpoints': orm.List(list=self._QPOINTS_LIST),
             },
         })
 

--- a/aiida_sssp_workflow/workflows/convergence/pressure.py
+++ b/aiida_sssp_workflow/workflows/convergence/pressure.py
@@ -105,6 +105,13 @@ def helper_get_v0_b0_b1(element: orm.Str):
 
 class ConvergencePressureWorkChain(WorkChain):
     """WorkChain to converge test on pressure of input structure"""
+
+    _DEGUASS = 0.00735
+    _OCCUPATIONS = 'smearing'
+    _SMEARING = 'marzari-vanderbilt'
+    _KDISTANCE = 0.15
+    _CONV_THR = 1e-10
+
     @classmethod
     def define(cls, spec):
         super().define(spec)
@@ -219,14 +226,14 @@ class ConvergencePressureWorkChain(WorkChain):
     def get_inputs(self, ecutwfc, ecutrho):
         _PW_PARAS = {   # pylint: disable=invalid-name
             'SYSTEM': {
-                'degauss': 0.00735,
-                'occupations': 'smearing',
-                'smearing': 'marzari-vanderbilt',
+                'degauss': self._DEGUASS,
+                'occupations': self._OCCUPATIONS,
+                'smearing': self._SMEARING,
                 'ecutrho': ecutrho,
                 'ecutwfc': ecutwfc,
             },
             'ELECTRONS': {
-                'conv_thr': 1e-10,
+                'conv_thr': self._CONV_THR,
             },
         }
 
@@ -237,7 +244,7 @@ class ConvergencePressureWorkChain(WorkChain):
             'parameters': {
                 'pw':
                 orm.Dict(dict=update_dict(_PW_PARAS, self.ctx.pw_parameters)),
-                'kpoints_distance': orm.Float(0.15),
+                'kpoints_distance': orm.Float(self._KDISTANCE),
             },
         })
 

--- a/aiida_sssp_workflow/workflows/convergence/pressure.py
+++ b/aiida_sssp_workflow/workflows/convergence/pressure.py
@@ -140,6 +140,11 @@ class ConvergencePressureWorkChain(WorkChain):
                    required=True,
                    default=lambda: orm.List(list=[200, 1600]),
                    help='ecutwfc/ecutrho pair for reference calculation.')
+        spec.input(
+            'parameters.v0_b0_b1',
+            valid_type=orm.Dict,
+            help=
+            'birch murnaghan fit results used in residual volume evaluation.')
         spec.outline(
             cls.setup,
             cls.validate_structure,
@@ -324,11 +329,11 @@ class ConvergencePressureWorkChain(WorkChain):
 
             absolute_diff = pressure - ref_pressure
 
-            element = self.inputs.pseudo.element
-            res = helper_get_v0_b0_b1(orm.Str(element))
+            res = self.inputs.parameters.v0_b0_b1
             V0, B0, B1 = res['V0'], res['B0'], res['B1']
             res = helper_get_volume_from_pressure_birch_murnaghan(
-                orm.Float(absolute_diff), V0, B0, B1)
+                orm.Float(absolute_diff), orm.Float(V0), orm.Float(B0),
+                orm.Float(B1))
             relative_diff = res.value
 
             relative_diffs.append(relative_diff)

--- a/aiida_sssp_workflow/workflows/delta_factor.py
+++ b/aiida_sssp_workflow/workflows/delta_factor.py
@@ -105,6 +105,20 @@ PW_PARAS = lambda: orm.Dict(dict={
 
 class DeltaFactorWorkChain(WorkChain):
     """Workchain to calculate delta factor of specific pseudopotential"""
+
+    _PW_PARAMETERS = {
+        'SYSTEM': {
+            'degauss': 0.00735,
+            'occupations': 'smearing',
+            'smearing': 'marzari-vanderbilt',
+        },
+        'ELECTRONS': {
+            'conv_thr': 1e-10,
+        },
+    }
+
+    _MAX_WALLCLOCK_SECONDS = 1800 * 2
+
     @classmethod
     def define(cls, spec):
         """Define the process specification."""
@@ -179,16 +193,7 @@ class DeltaFactorWorkChain(WorkChain):
         """Input validation"""
         # TODO set ecutwfc and ecutrho according to certain protocol
 
-        pw_parameters = {
-            'SYSTEM': {
-                'degauss': 0.00735,
-                'occupations': 'smearing',
-                'smearing': 'marzari-vanderbilt',
-            },
-            'ELECTRONS': {
-                'conv_thr': 1e-10,
-            },
-        }
+        pw_parameters = self._PW_PARAMETERS
 
         self.ctx.pw_parameters = orm.Dict(dict=update_dict(
             pw_parameters, self.inputs.parameters.pw.get_dict()))
@@ -293,7 +298,8 @@ class DeltaFactorWorkChain(WorkChain):
             from aiida_quantumespresso.utils.resources import get_default_options
 
             inputs.options = orm.Dict(dict=get_default_options(
-                max_wallclock_seconds=3600, with_mpi=True))
+                max_wallclock_seconds=self._MAX_WALLCLOCK_SECONDS,
+                with_mpi=True))
 
         self.report(f'options is {inputs.options.attributes}')
         running = self.submit(EquationOfStateWorkChain, **inputs)

--- a/aiida_sssp_workflow/workflows/delta_factor.py
+++ b/aiida_sssp_workflow/workflows/delta_factor.py
@@ -97,7 +97,6 @@ def helper_get_magnetic_inputs(structure: orm.StructureData):
 
 PW_PARAS = lambda: orm.Dict(dict={
     'SYSTEM': {
-        'degauss': 0.00735,
         'ecutrho': 1600,
         'ecutwfc': 200,
     },
@@ -170,16 +169,6 @@ class DeltaFactorWorkChain(WorkChain):
                     valid_type=orm.Str,
                     required=True,
                     help='The element of the pseudopotential.')
-        spec.output(
-            'eos_initial_cif',
-            valid_type=orm.CifData,
-            required=False,
-            help='The standard cif file provided in sssp_workflow package.')
-        spec.output(
-            'eos_initial_structure',
-            valid_type=orm.StructureData,
-            help='The initial input structure used for calculate delta factor.'
-        )
         # TODO delta prime out
         spec.exit_code(
             201,
@@ -192,6 +181,7 @@ class DeltaFactorWorkChain(WorkChain):
 
         pw_parameters = {
             'SYSTEM': {
+                'degauss': 0.00735,
                 'occupations': 'smearing',
                 'smearing': 'marzari-vanderbilt',
             },
@@ -256,8 +246,6 @@ class DeltaFactorWorkChain(WorkChain):
                 # The Cif is already store let's return it
                 cif_data = orm.CifData.get_or_create(filename)[0]
 
-            self.out('eos_initial_cif', cif_data)
-
             if self.ctx.element.value not in MAGNETIC_ELEMENTS:
                 self.ctx.structure = cif_data.get_structure()
             else:
@@ -278,8 +266,6 @@ class DeltaFactorWorkChain(WorkChain):
 
         else:
             self.ctx.structure = self.inputs.structure
-
-        self.out('eos_initial_structure', self.ctx.structure)
 
     def run_eos(self):
         """run eos workchain"""

--- a/aiida_sssp_workflow/workflows/phonon_frequencies.py
+++ b/aiida_sssp_workflow/workflows/phonon_frequencies.py
@@ -155,7 +155,7 @@ class PhononFrequenciesWorkChain(WorkChain):
                 'pseudos': self.ctx.pseudos,
                 'parameters': orm.Dict(dict=self.ctx.pw_parameters),
                 'settings':
-                orm.Dict(dict={'CMDLINE': ['-ndiag', '1', '-nk', '2']}),
+                orm.Dict(dict={'CMDLINE': ['-ndiag', '1', '-nk', '4']}),
                 'metadata': {},
             },
             'kpoints_distance': self.ctx.kpoints_distance,

--- a/aiida_sssp_workflow/workflows/phonon_frequencies.py
+++ b/aiida_sssp_workflow/workflows/phonon_frequencies.py
@@ -107,9 +107,13 @@ class PhononFrequenciesWorkChain(WorkChain):
                 'occupations': 'smearing',
                 'smearing': 'marzari-vanderbilt',
             },
+            'ELECTRONS': {
+                'conv_thr': 1e-10,
+            },
             'CONTROL': {
                 'calculation': 'scf',
                 'wf_collect': True,
+                'tstress': True,
             },
         }
         pw_parameters = update_dict(pw_parameters,

--- a/aiida_sssp_workflow/workflows/phonon_frequencies.py
+++ b/aiida_sssp_workflow/workflows/phonon_frequencies.py
@@ -149,7 +149,7 @@ class PhononFrequenciesWorkChain(WorkChain):
                 'structure': self.inputs.structure,
                 'code': self.inputs.pw_code,
                 'pseudos': self.ctx.pseudos,
-                'parameters': self.ctx.pw_parameters,
+                'parameters': orm.Dict(dict=self.ctx.pw_parameters),
                 'settings':
                 orm.Dict(dict={'CMDLINE': ['-ndiag', '1', '-nk', '2']}),
                 'metadata': {},
@@ -196,7 +196,7 @@ class PhononFrequenciesWorkChain(WorkChain):
             'ph': {
                 'code': self.inputs.ph_code,
                 'qpoints': self.ctx.qpoints,
-                'parameters': self.ctx.ph_parameters,
+                'parameters': orm.Dict(dict=self.ctx.ph_parameters),
                 'parent_folder': self.ctx.scf_remote_folder,
                 'settings': orm.Dict(dict={'CMDLINE': ['-nk', '2']}),
                 'metadata': {},

--- a/aiida_sssp_workflow/workflows/pressure.py
+++ b/aiida_sssp_workflow/workflows/pressure.py
@@ -128,7 +128,8 @@ class PressureEvaluationWorkChain(WorkChain):
                 'code': self.inputs.code,
                 'pseudos': self.ctx.pseudos,
                 'parameters': orm.Dict(dict=self.ctx.pw_parameters),
-                'settings': orm.Dict(dict={'CMDLINE': ['-ndiag', '1']}),
+                'settings':
+                orm.Dict(dict={'CMDLINE': ['-ndiag', '1', '-nk', '4']}),
                 'metadata': {},
             },
             'kpoints_distance': self.ctx.kpoints_distance,

--- a/aiida_sssp_workflow/workflows/pressure.py
+++ b/aiida_sssp_workflow/workflows/pressure.py
@@ -101,6 +101,8 @@ class PressureEvaluationWorkChain(WorkChain):
                 'conv_thr': 1e-10,
             },
             'CONTROL': {
+                'calculation': 'scf',
+                'wf_collect': True,
                 'tstress': True,
             },
         }

--- a/examples/example_band.py
+++ b/examples/example_band.py
@@ -55,9 +55,9 @@ if __name__ == '__main__':
 
     upf_sg15 = {}
     # # sg15/Au_ONCV_PBE-1.2.upf
-    # upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
+    upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
     # sg15/Si_ONCV_PBE-1.2.upf
-    upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
+    # upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
     # # sg15/Xe_ONCV_PBE-1.2.upf
     # upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
     # # sg15/Fe_ONCV_PBE-1.2.upf

--- a/examples/example_band.py
+++ b/examples/example_band.py
@@ -1,33 +1,20 @@
 #!/usr/bin/env python
+import numpy as np
+
+from aiida import orm
 from aiida.common import AttributeDict
 from aiida.plugins import WorkflowFactory
 from aiida.engine import submit
 
-from aiida_sssp_workflow.calculations.helper_functions import helper_get_primitive_structure
-
 ConvergenceBandsWorkChain = WorkflowFactory('sssp_workflow.convergence.bands')
 
-if __name__ == '__main__':
-    from aiida import orm
-    from aiida.orm import load_code, load_node
 
-    code = load_code('qe-6.6-pw@daint-mc')
-
-    # # Silicon structure and pseudopotential
-    # upf = load_node('9d9d57fc-49e3-4e0c-8c37-4682ccc0fb51')
-
-    # Fluorine pseude
-    # upf = load_node('a1b60d81-d5a3-4ddb-a31a-d5b608c1ba52')
-
-    # gold structure and pseudopotential
-    # upf = load_node('197acb08-ff93-4e65-8de9-2242a96197b2') # NC
-    # upf = load_node('61830c2b-fa08-4e92-9571-1141ded79612')  # PAW
-
-    # Lanthanum
-    upf = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
-
-    PARA_ECUTWFC_LIST = orm.List(list=[20, 25, 200])
-    PARA_ECUTRHO_LIST = orm.List(list=[160, 200, 1600])
+def run_test(code, upf, dual):
+    ecutwfc = np.array(
+        [30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 90, 100, 120, 150, 200])
+    ecutrho = ecutwfc * dual
+    PARA_ECUTWFC_LIST = orm.List(list=list(ecutwfc))
+    PARA_ECUTRHO_LIST = orm.List(list=list(ecutrho))
 
     inputs = AttributeDict({
         'code': code,
@@ -35,7 +22,64 @@ if __name__ == '__main__':
         'parameters': {
             'ecutwfc_list': PARA_ECUTWFC_LIST,
             'ecutrho_list': PARA_ECUTRHO_LIST,
+            'ref_cutoff_pair': orm.List(list=[200, 200 * dual])
         },
     })
     node = submit(ConvergenceBandsWorkChain, **inputs)
-    print(node)
+
+    return node
+
+
+if __name__ == '__main__':
+    from aiida.orm import load_code, load_node
+
+    code = load_code('qe-6.6-pw@daint-mc')
+
+    upf_gbrv = {}
+    # GBRV_pbe/si_pbe_v1.uspp.F.UPF
+    upf_gbrv['si'] = load_node('15f938a1-9466-4a41-9022-4c6f06cf4e20')
+    # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
+    upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
+    # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
+    upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
+    # GBRV_pbe/au_pbe_v1.uspp.F.UPF
+    upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
+
+    for element, upf in upf_gbrv.items():
+        if element == 'fe':
+            dual = 12.0
+        else:
+            dual = 8.0
+        node = run_test(code, upf, dual)
+        node.description = f'GBRV_pbe/{element}'
+        print(node)
+
+    upf_sg15 = {}
+    # sg15/Au_ONCV_PBE-1.2.upf
+    upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
+    # sg15/Si_ONCV_PBE-1.2.upf
+    upf_sg15['si'] = load_node('f382f1ff-c44e-4381-886c-81cb5936b8a0')
+    # sg15/Xe_ONCV_PBE-1.2.upf
+    upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
+    # sg15/Fe_ONCV_PBE-1.2.upf
+    upf_sg15['fe'] = load_node('12aeff74-048d-4199-b97e-2b996e7fc2d3')
+    # sg15/F_ONCV_PBE-1.2.upf
+    upf_sg15['f'] = load_node('3ef1d267-b442-43fb-bc29-7113761ca15b')
+
+    for element, upf in upf_sg15.items():
+        dual = 4.0
+        node = run_test(code, upf, dual)
+        node.description = f'sg15/{element}'
+        print(node)
+
+    # test on lanthanides
+    upf_wt = {}
+    # WT/La.GGA-PBE-paw-v1.0.UPF
+    upf_wt['La'] = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
+    # WT/Eu.GGA-PBE-paw-v1.0.UPF
+    upf_wt['Eu'] = load_node('220a8ebd-0ac5-44f1-a6a9-0790b24965a9')
+
+    for element, upf in upf_wt.items():
+        node = run_test(code, upf, dual=8.0)
+        node.description = f'WT/{element}-PBE'
+        print(node)

--- a/examples/example_band.py
+++ b/examples/example_band.py
@@ -34,43 +34,43 @@ if __name__ == '__main__':
 
     code = load_code('qe-6.6-pw@daint-mc')
 
-    upf_gbrv = {}
-    # GBRV_pbe/si_pbe_v1.uspp.F.UPF
-    upf_gbrv['si'] = load_node(28953)
-    # # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
-    # upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
-    # # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
-    # upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
-    # # GBRV_pbe/au_pbe_v1.uspp.F.UPF
-    # upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
+    # upf_gbrv = {}
+    # # GBRV_pbe/si_pbe_v1.uspp.F.UPF
+    # upf_gbrv['si'] = load_node(28953)
+    # # # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
+    # # upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
+    # # # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
+    # # upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
+    # # # GBRV_pbe/au_pbe_v1.uspp.F.UPF
+    # # upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
+    #
+    # for element, upf in upf_gbrv.items():
+    #     if element == 'fe':
+    #         dual = 12.0
+    #     else:
+    #         dual = 8.0
+    #     node = run_test(code, upf, dual)
+    #     node.description = f'GBRV_pbe/{element}'
+    #     print(node)
 
-    for element, upf in upf_gbrv.items():
-        if element == 'fe':
-            dual = 12.0
-        else:
-            dual = 8.0
-        node = run_test(code, upf, dual)
-        node.description = f'GBRV_pbe/{element}'
-        print(node)
-
-    # upf_sg15 = {}
+    upf_sg15 = {}
     # # sg15/Au_ONCV_PBE-1.2.upf
     # upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
-    # # sg15/Si_ONCV_PBE-1.2.upf
-    # upf_sg15['si'] = load_node('f382f1ff-c44e-4381-886c-81cb5936b8a0')
+    # sg15/Si_ONCV_PBE-1.2.upf
+    upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
     # # sg15/Xe_ONCV_PBE-1.2.upf
     # upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
     # # sg15/Fe_ONCV_PBE-1.2.upf
     # upf_sg15['fe'] = load_node('12aeff74-048d-4199-b97e-2b996e7fc2d3')
     # # sg15/F_ONCV_PBE-1.2.upf
     # upf_sg15['f'] = load_node('3ef1d267-b442-43fb-bc29-7113761ca15b')
-    #
-    # for element, upf in upf_sg15.items():
-    #     dual = 4.0
-    #     node = run_test(code, upf, dual)
-    #     node.description = f'sg15/{element}'
-    #     print(node)
-    #
+
+    for element, upf in upf_sg15.items():
+        dual = 4.0
+        node = run_test(code, upf, dual)
+        node.description = f'sg15/{element}'
+        print(node)
+
     # # test on lanthanides
     # upf_wt = {}
     # # WT/La.GGA-PBE-paw-v1.0.UPF

--- a/examples/example_band.py
+++ b/examples/example_band.py
@@ -55,9 +55,9 @@ if __name__ == '__main__':
 
     upf_sg15 = {}
     # # sg15/Au_ONCV_PBE-1.2.upf
-    upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
+    # upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
     # sg15/Si_ONCV_PBE-1.2.upf
-    # upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
+    upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
     # # sg15/Xe_ONCV_PBE-1.2.upf
     # upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
     # # sg15/Fe_ONCV_PBE-1.2.upf

--- a/examples/example_band.py
+++ b/examples/example_band.py
@@ -55,7 +55,7 @@ if __name__ == '__main__':
 
     upf_sg15 = {}
     # # sg15/Au_ONCV_PBE-1.2.upf
-    # upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
+    upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
     # sg15/Si_ONCV_PBE-1.2.upf
     upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
     # # sg15/Xe_ONCV_PBE-1.2.upf

--- a/examples/example_band.py
+++ b/examples/example_band.py
@@ -10,8 +10,7 @@ ConvergenceBandsWorkChain = WorkflowFactory('sssp_workflow.convergence.bands')
 
 
 def run_test(code, upf, dual):
-    ecutwfc = np.array(
-        [30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 90, 100, 120, 150, 200])
+    ecutwfc = np.array([30, 35, 200])
     ecutrho = ecutwfc * dual
     PARA_ECUTWFC_LIST = orm.List(list=list(ecutwfc))
     PARA_ECUTRHO_LIST = orm.List(list=list(ecutrho))
@@ -37,13 +36,13 @@ if __name__ == '__main__':
 
     upf_gbrv = {}
     # GBRV_pbe/si_pbe_v1.uspp.F.UPF
-    upf_gbrv['si'] = load_node('15f938a1-9466-4a41-9022-4c6f06cf4e20')
-    # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
-    upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
-    # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
-    upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
-    # GBRV_pbe/au_pbe_v1.uspp.F.UPF
-    upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
+    upf_gbrv['si'] = load_node(28953)
+    # # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
+    # upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
+    # # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
+    # upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
+    # # GBRV_pbe/au_pbe_v1.uspp.F.UPF
+    # upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
 
     for element, upf in upf_gbrv.items():
         if element == 'fe':
@@ -54,32 +53,32 @@ if __name__ == '__main__':
         node.description = f'GBRV_pbe/{element}'
         print(node)
 
-    upf_sg15 = {}
-    # sg15/Au_ONCV_PBE-1.2.upf
-    upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
-    # sg15/Si_ONCV_PBE-1.2.upf
-    upf_sg15['si'] = load_node('f382f1ff-c44e-4381-886c-81cb5936b8a0')
-    # sg15/Xe_ONCV_PBE-1.2.upf
-    upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
-    # sg15/Fe_ONCV_PBE-1.2.upf
-    upf_sg15['fe'] = load_node('12aeff74-048d-4199-b97e-2b996e7fc2d3')
-    # sg15/F_ONCV_PBE-1.2.upf
-    upf_sg15['f'] = load_node('3ef1d267-b442-43fb-bc29-7113761ca15b')
-
-    for element, upf in upf_sg15.items():
-        dual = 4.0
-        node = run_test(code, upf, dual)
-        node.description = f'sg15/{element}'
-        print(node)
-
-    # test on lanthanides
-    upf_wt = {}
-    # WT/La.GGA-PBE-paw-v1.0.UPF
-    upf_wt['La'] = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
-    # WT/Eu.GGA-PBE-paw-v1.0.UPF
-    upf_wt['Eu'] = load_node('220a8ebd-0ac5-44f1-a6a9-0790b24965a9')
-
-    for element, upf in upf_wt.items():
-        node = run_test(code, upf, dual=8.0)
-        node.description = f'WT/{element}-PBE'
-        print(node)
+    # upf_sg15 = {}
+    # # sg15/Au_ONCV_PBE-1.2.upf
+    # upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
+    # # sg15/Si_ONCV_PBE-1.2.upf
+    # upf_sg15['si'] = load_node('f382f1ff-c44e-4381-886c-81cb5936b8a0')
+    # # sg15/Xe_ONCV_PBE-1.2.upf
+    # upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
+    # # sg15/Fe_ONCV_PBE-1.2.upf
+    # upf_sg15['fe'] = load_node('12aeff74-048d-4199-b97e-2b996e7fc2d3')
+    # # sg15/F_ONCV_PBE-1.2.upf
+    # upf_sg15['f'] = load_node('3ef1d267-b442-43fb-bc29-7113761ca15b')
+    #
+    # for element, upf in upf_sg15.items():
+    #     dual = 4.0
+    #     node = run_test(code, upf, dual)
+    #     node.description = f'sg15/{element}'
+    #     print(node)
+    #
+    # # test on lanthanides
+    # upf_wt = {}
+    # # WT/La.GGA-PBE-paw-v1.0.UPF
+    # upf_wt['La'] = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
+    # # WT/Eu.GGA-PBE-paw-v1.0.UPF
+    # upf_wt['Eu'] = load_node('220a8ebd-0ac5-44f1-a6a9-0790b24965a9')
+    #
+    # for element, upf in upf_wt.items():
+    #     node = run_test(code, upf, dual=8.0)
+    #     node.description = f'WT/{element}-PBE'
+    #     print(node)

--- a/examples/example_cohesive_energy.py
+++ b/examples/example_cohesive_energy.py
@@ -57,9 +57,9 @@ if __name__ == '__main__':
 
     upf_sg15 = {}
     # # sg15/Au_ONCV_PBE-1.2.upf
-    upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
+    # upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
     # sg15/Si_ONCV_PBE-1.2.upf
-    # upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
+    upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
     # # sg15/Xe_ONCV_PBE-1.2.upf
     # upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
     # # sg15/Fe_ONCV_PBE-1.2.upf

--- a/examples/example_cohesive_energy.py
+++ b/examples/example_cohesive_energy.py
@@ -57,9 +57,9 @@ if __name__ == '__main__':
 
     upf_sg15 = {}
     # # sg15/Au_ONCV_PBE-1.2.upf
-    # upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
+    upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
     # sg15/Si_ONCV_PBE-1.2.upf
-    upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
+    # upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
     # # sg15/Xe_ONCV_PBE-1.2.upf
     # upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
     # # sg15/Fe_ONCV_PBE-1.2.upf

--- a/examples/example_cohesive_energy.py
+++ b/examples/example_cohesive_energy.py
@@ -12,8 +12,7 @@ ConvergenceCohesiveEnergy = WorkflowFactory(
 
 
 def run_test(code, upf, dual):
-    ecutwfc = np.array(
-        [30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 90, 100, 120, 150, 200])
+    ecutwfc = np.array([30, 35, 200])
     ecutrho = ecutwfc * dual
     PARA_ECUTWFC_LIST = orm.List(list=list(ecutwfc))
     PARA_ECUTRHO_LIST = orm.List(list=list(ecutrho))
@@ -37,36 +36,36 @@ if __name__ == '__main__':
 
     code = load_code('qe-6.6-pw@daint-mc')
 
-    upf_gbrv = {}
-    # GBRV_pbe/si_pbe_v1.uspp.F.UPF
-    upf_gbrv['si'] = load_node('15f938a1-9466-4a41-9022-4c6f06cf4e20')
-    # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
-    upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
-    # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
-    upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
-    # GBRV_pbe/au_pbe_v1.uspp.F.UPF
-    upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
-
-    for element, upf in upf_gbrv.items():
-        if element == 'fe':
-            dual = 12.0
-        else:
-            dual = 8.0
-        node = run_test(code, upf, dual)
-        node.description = f'GBRV_pbe/{element}'
-        print(node)
+    # upf_gbrv = {}
+    # # GBRV_pbe/si_pbe_v1.uspp.F.UPF
+    # upf_gbrv['si'] = load_node('15f938a1-9466-4a41-9022-4c6f06cf4e20')
+    # # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
+    # upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
+    # # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
+    # upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
+    # # GBRV_pbe/au_pbe_v1.uspp.F.UPF
+    # upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
+    #
+    # for element, upf in upf_gbrv.items():
+    #     if element == 'fe':
+    #         dual = 12.0
+    #     else:
+    #         dual = 8.0
+    #     node = run_test(code, upf, dual)
+    #     node.description = f'GBRV_pbe/{element}'
+    #     print(node)
 
     upf_sg15 = {}
-    # sg15/Au_ONCV_PBE-1.2.upf
-    upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
+    # # sg15/Au_ONCV_PBE-1.2.upf
+    # upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
     # sg15/Si_ONCV_PBE-1.2.upf
-    upf_sg15['si'] = load_node('f382f1ff-c44e-4381-886c-81cb5936b8a0')
-    # sg15/Xe_ONCV_PBE-1.2.upf
-    upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
-    # sg15/Fe_ONCV_PBE-1.2.upf
-    upf_sg15['fe'] = load_node('12aeff74-048d-4199-b97e-2b996e7fc2d3')
-    # sg15/F_ONCV_PBE-1.2.upf
-    upf_sg15['f'] = load_node('3ef1d267-b442-43fb-bc29-7113761ca15b')
+    upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
+    # # sg15/Xe_ONCV_PBE-1.2.upf
+    # upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
+    # # sg15/Fe_ONCV_PBE-1.2.upf
+    # upf_sg15['fe'] = load_node('12aeff74-048d-4199-b97e-2b996e7fc2d3')
+    # # sg15/F_ONCV_PBE-1.2.upf
+    # upf_sg15['f'] = load_node('3ef1d267-b442-43fb-bc29-7113761ca15b')
 
     for element, upf in upf_sg15.items():
         dual = 4.0
@@ -74,14 +73,14 @@ if __name__ == '__main__':
         node.description = f'sg15/{element}'
         print(node)
 
-    # test on lanthanides
-    upf_wt = {}
-    # WT/La.GGA-PBE-paw-v1.0.UPF
-    upf_wt['La'] = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
-    # WT/Eu.GGA-PBE-paw-v1.0.UPF
-    upf_wt['Eu'] = load_node('220a8ebd-0ac5-44f1-a6a9-0790b24965a9')
-
-    for element, upf in upf_wt.items():
-        node = run_test(code, upf, dual=8.0)
-        node.description = f'WT/{element}-PBE'
-        print(node)
+    # # test on lanthanides
+    # upf_wt = {}
+    # # WT/La.GGA-PBE-paw-v1.0.UPF
+    # upf_wt['La'] = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
+    # # WT/Eu.GGA-PBE-paw-v1.0.UPF
+    # upf_wt['Eu'] = load_node('220a8ebd-0ac5-44f1-a6a9-0790b24965a9')
+    #
+    # for element, upf in upf_wt.items():
+    #     node = run_test(code, upf, dual=8.0)
+    #     node.description = f'WT/{element}-PBE'
+    #     print(node)

--- a/examples/example_cohesive_energy.py
+++ b/examples/example_cohesive_energy.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
+import numpy as np
+
 from aiida.common import AttributeDict
+from aiida import orm
 from aiida.plugins import WorkflowFactory
 
 from aiida.engine import run_get_node, submit
@@ -7,27 +10,13 @@ from aiida.engine import run_get_node, submit
 ConvergenceCohesiveEnergy = WorkflowFactory(
     'sssp_workflow.convergence.cohesive_energy')
 
-if __name__ == '__main__':
-    from aiida import orm
-    from aiida.orm import load_code, load_node
 
-    code = load_code('qe-6.6-pw@daint-mc')
-
-    # # Silicon structure and pseudopotential
-    # upf = load_node('9d9d57fc-49e3-4e0c-8c37-4682ccc0fb51')
-
-    # Fluorine pseude
-    # upf = load_node('a1b60d81-d5a3-4ddb-a31a-d5b608c1ba52')
-
-    # gold structure and pseudopotential
-    # upf = load_node('197acb08-ff93-4e65-8de9-2242a96197b2') # NC
-    upf = load_node('61830c2b-fa08-4e92-9571-1141ded79612')  # PAW
-
-    # Lanthanum
-    # upf = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
-
-    PARA_ECUTWFC_LIST = orm.List(list=[20, 25, 200])
-    PARA_ECUTRHO_LIST = orm.List(list=[160, 200, 1600])
+def run_test(code, upf, dual):
+    ecutwfc = np.array(
+        [30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 90, 100, 120, 150, 200])
+    ecutrho = ecutwfc * dual
+    PARA_ECUTWFC_LIST = orm.List(list=list(ecutwfc))
+    PARA_ECUTRHO_LIST = orm.List(list=list(ecutrho))
 
     inputs = AttributeDict({
         'code': code,
@@ -35,8 +24,64 @@ if __name__ == '__main__':
         'parameters': {
             'ecutwfc_list': PARA_ECUTWFC_LIST,
             'ecutrho_list': PARA_ECUTRHO_LIST,
+            'ref_cutoff_pair': orm.List(list=[200, 200 * dual])
         },
     })
     node = submit(ConvergenceCohesiveEnergy, **inputs)
-    node.description = f'[{upf.element}]'
-    print(node)
+
+    return node
+
+
+if __name__ == '__main__':
+    from aiida.orm import load_code, load_node
+
+    code = load_code('qe-6.6-pw@daint-mc')
+
+    upf_gbrv = {}
+    # GBRV_pbe/si_pbe_v1.uspp.F.UPF
+    upf_gbrv['si'] = load_node('15f938a1-9466-4a41-9022-4c6f06cf4e20')
+    # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
+    upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
+    # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
+    upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
+    # GBRV_pbe/au_pbe_v1.uspp.F.UPF
+    upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
+
+    for element, upf in upf_gbrv.items():
+        if element == 'fe':
+            dual = 12.0
+        else:
+            dual = 8.0
+        node = run_test(code, upf, dual)
+        node.description = f'GBRV_pbe/{element}'
+        print(node)
+
+    upf_sg15 = {}
+    # sg15/Au_ONCV_PBE-1.2.upf
+    upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
+    # sg15/Si_ONCV_PBE-1.2.upf
+    upf_sg15['si'] = load_node('f382f1ff-c44e-4381-886c-81cb5936b8a0')
+    # sg15/Xe_ONCV_PBE-1.2.upf
+    upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
+    # sg15/Fe_ONCV_PBE-1.2.upf
+    upf_sg15['fe'] = load_node('12aeff74-048d-4199-b97e-2b996e7fc2d3')
+    # sg15/F_ONCV_PBE-1.2.upf
+    upf_sg15['f'] = load_node('3ef1d267-b442-43fb-bc29-7113761ca15b')
+
+    for element, upf in upf_sg15.items():
+        dual = 4.0
+        node = run_test(code, upf, dual)
+        node.description = f'sg15/{element}'
+        print(node)
+
+    # test on lanthanides
+    upf_wt = {}
+    # WT/La.GGA-PBE-paw-v1.0.UPF
+    upf_wt['La'] = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
+    # WT/Eu.GGA-PBE-paw-v1.0.UPF
+    upf_wt['Eu'] = load_node('220a8ebd-0ac5-44f1-a6a9-0790b24965a9')
+
+    for element, upf in upf_wt.items():
+        node = run_test(code, upf, dual=8.0)
+        node.description = f'WT/{element}-PBE'
+        print(node)

--- a/examples/example_cohesive_energy.py
+++ b/examples/example_cohesive_energy.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
 
     upf_sg15 = {}
     # # sg15/Au_ONCV_PBE-1.2.upf
-    # upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
+    upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
     # sg15/Si_ONCV_PBE-1.2.upf
     upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
     # # sg15/Xe_ONCV_PBE-1.2.upf

--- a/examples/example_delta_factor.py
+++ b/examples/example_delta_factor.py
@@ -11,7 +11,7 @@ from aiida.engine import run_get_node, submit
 DeltaFactorWorkChain = WorkflowFactory('sssp_workflow.delta_factor')
 
 
-def run_delta(code, upf, structure=None, is_nc=False):
+def run_delta(code, upf, is_nc=False):
 
     if is_nc:
         dual = 4
@@ -35,12 +35,6 @@ def run_delta(code, upf, structure=None, is_nc=False):
                 'withmpi': True,
             }),
         'parameters': {
-            'scale_count':
-            orm.Int(7),
-            'scale_increment':
-            orm.Float(0.02),
-            'kpoints_distance':
-            orm.Float(0.1),
             'pw':
             orm.Dict(dict={
                 'SYSTEM': {
@@ -51,9 +45,6 @@ def run_delta(code, upf, structure=None, is_nc=False):
         },
     })
 
-    if structure:
-        inputs.update({'structure': structure})
-
     node = submit(DeltaFactorWorkChain, **inputs)
     return node
 
@@ -63,123 +54,42 @@ if __name__ == '__main__':
 
     code = load_code('qe-6.6-pw@daint-mc')
 
-    # # GBRV_pbe/au_pbe_v1.uspp.F.UPF
-    # upf = load_node('5b2176f8-0d40-44c9-a902-f260c94d62ca')
-    #
-    # node = run_delta(code, upf, is_nc=False)
-    # node.description = 'GBRV_pbe/au_pbe_v1.uspp.F.UPF'
-    # print(node)
-    #
-    # # Au_ONCV_PBE-1.0.oncvpsp.upf
-    # upf = load_node('197acb08-ff93-4e65-8de9-2242a96197b2')
-    #
-    # # maximum inputs
-    # node = run_delta(code, upf, is_nc=True)
-    # node.description = 'Au_ONCV_PBE-1.0.oncvpsp.upf'
-    # print(node)
-
-    # # sg15/Cr_ONCV_PBE-1.2.upf
-    # upf = load_node('d49cc506-c9a4-4247-9111-0266249e102e')
-    #
-    # # maximum inputs
-    # node = run_delta(code, upf, is_nc=True)
-    # node.description = 'sg15/Cr_ONCV_PBE-1.2.upf'
-    # print(node)
-
-    # # GBRV_pbe/si_pbe_v1.uspp.F.UPF
-    # upf = load_node('65f0427b-4cc5-4311-9f22-6a29a7771e1f')
-    #
-    # node = run_delta(code, upf, is_nc=False)
-    # node.description = 'GBRV_pbe/si_pbe_v1.uspp.F.UPF'
-    # print(node)
-
-    # sg15/Si_ONCV_PBE-1.2.upf
-    # upf = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
-    #
-    # node = run_delta(code, upf, is_nc=True)
-    # node.description = 'sg15/Si_ONCV_PBE-1.2.upf'
-    # print(node)
-
-    #
-    #
-    # Si.pbe-n-rrkjus_psl.1.0.0.UPF
-    # upf = load_node('154bf3b5-7f93-4dd4-9770-ca9a9673beed')
-    #
-    # node = run_delta(code, upf, is_nc=False)
-    # node.description = 'Si.pbe-n-rrkjus_psl.1.0.0.UPF'
-    # print(node)
-
-    # # sg15/Au_ONCV_PBE-1.2.upf
-    # upf = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
-    #
-    # # maximum inputs
-    # node = run_delta(code, upf, is_nc=True)
-    # node.description = 'sg15/Au_ONCV_PBE-1.2.upf'
-    # print(node)
-    #
-    # # sg15/Au_ONCV_PBE-1.0.upf
-    # upf = load_node('6be3e57a-bca0-4b84-aff8-7682e17eb9c9')
-    #
-    # # maximum inputs
-    # node = run_delta(code, upf, is_nc=True)
-    # node.description = 'sg15/Au_ONCV_PBE-1.0.upf'
-    # print(node)
-    #
-    # # sg15/Au_ONCV_PBE_FR-1.0.upf
-    # upf = load_node('c4594201-f325-4c0b-890c-18ad051c9c57')
-    #
-    # # maximum inputs
-    # node = run_delta(code, upf, is_nc=True)
-    # node.description = 'sg15/Au_ONCV_PBE_FR-1.0.upf'
-    # print(node)
-    #
-    # # La.GGA-PBE-paw-v1.0.UPF
-    # from aiida.manage.caching import disable_caching
-    # with disable_caching(identifier='aiida.calculations:quantumespresso.pw'):
-    #     upf = load_node('a8302677-a72a-4775-8b6a-66b8f6283ff3')
-    #
-    #     # maximum inputs
-    #     node = run_delta(code, upf, is_nc=False)
-    #     node.description = 'La.GGA-PBE-paw-v1.0.UPF'
-    #     print(node)
-
-    # # GBRV_pbe/la_pbe_v1.uspp.F.UPF
-    # upf = load_node('64faeb7a-ab34-4bcc-9f24-84895d7fa42e')
-    #
-    # # maximum inputs
-    # node = run_delta(code, upf, is_nc=False)
-    # node.description = 'GBRV_pbe/la_pbe_v1.uspp.F.UPF'
-    # print(node)
-
-    # Eu.GGA-PBE-paw-v1.0.UPF
-    upf = load_node('220a8ebd-0ac5-44f1-a6a9-0790b24965a9')
-
-    # maximum inputs
-    node = run_delta(code, upf, is_nc=False)
-    node.description = 'WT/Eu.GGA-PBE-paw-v1.0.UPF'
-    print(node)
-
-    # sg15/O_ONCV_PBE-1.2.upf
-    # upf = load_node('804b71ea-6d9b-4d80-a343-fd38f8d59382')
-    #
-    # # maximum inputs
-    # node = run_delta(code, upf, is_nc=True)
-    # node.description = 'sg15/O_ONCV_PBE-1.2.upf'
-    # print(node)
-
+    upf_gbrv = {}
+    # GBRV_pbe/au_pbe_v1.uspp.F.UPF
+    upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
     # GBRV_pbe/o_pbe_v1.2.uspp.F.UPF
-    # upf = load_node('be9781ac-7578-4cef-8c53-68173b3eff9a')
-    #
-    # # maximum inputs
-    # node = run_delta(code, upf, is_nc=False)
-    # node.description = 'GBRV_pbe/o_pbe_v1.2.uspp.F.UPF'
-    # print(node)
+    upf_gbrv['o'] = load_node('005f1eaa-6746-41f2-8b12-38f6dabe4f61')
+    # GBRV_pbe/si_pbe_v1.uspp.F.UPF
+    upf_gbrv['si'] = load_node('15f938a1-9466-4a41-9022-4c6f06cf4e20')
 
-    #
-    # # sg15/Mn_ONCV_PBE-1.2.upf
-    # upf = load_node('8daf2779-b72b-49d0-98b1-7bed7f86a9b9')
-    #
-    # # maximum inputs
-    # node = run_delta(code, upf, is_nc=True)
-    # node.description = 'sg15/Mn_ONCV_PBE-1.2.upf'
-    # print(node)
+    for element, upf in upf_gbrv.items():
+        node = run_delta(code, upf, is_nc=False)
+        node.description = f'GBRV_pbe/{element}'
+        print(node)
+
+    upf_sg15 = {}
+    # sg15/Au_ONCV_PBE-1.2.upf
+    upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
+    # sg15/O_ONCV_PBE-1.2.upf
+    upf_sg15['o'] = load_node('52e4e647-d6ef-43c6-b8a1-adfb54bff07e')
+    # sg15/Si_ONCV_PBE-1.2.upf
+    upf_sg15['si'] = load_node('f382f1ff-c44e-4381-886c-81cb5936b8a0')
+    # sg15/Xe_ONCV_PBE-1.2.upf
+    upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
+
+    for element, upf in upf_sg15.items():
+        node = run_delta(code, upf, is_nc=True)
+        node.description = f'sg15/{element}'
+        print(node)
+
+    # test on lanthanides
+    upf_wt = {}
+    # WT/La.GGA-PBE-paw-v1.0.UPF
+    upf_wt['La'] = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
+    # WT/Eu.GGA-PBE-paw-v1.0.UPF
+    upf_wt['Eu'] = load_node('220a8ebd-0ac5-44f1-a6a9-0790b24965a9')
+
+    for element, upf in upf_wt.items():
+        node = run_delta(code, upf, is_nc=False)
+        node.description = f'WT/{element}-PBE'
+        print(node)

--- a/examples/example_delta_factor.py
+++ b/examples/example_delta_factor.py
@@ -69,7 +69,7 @@ if __name__ == '__main__':
 
     upf_sg15 = {}
     # sg15/Au_ONCV_PBE-1.2.upf
-    # upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
+    upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
     # # sg15/O_ONCV_PBE-1.2.upf
     # upf_sg15['o'] = load_node('52e4e647-d6ef-43c6-b8a1-adfb54bff07e')
     # sg15/Si_ONCV_PBE-1.2.upf

--- a/examples/example_delta_factor.py
+++ b/examples/example_delta_factor.py
@@ -69,11 +69,11 @@ if __name__ == '__main__':
 
     upf_sg15 = {}
     # sg15/Au_ONCV_PBE-1.2.upf
-    upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
+    # upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
     # # sg15/O_ONCV_PBE-1.2.upf
     # upf_sg15['o'] = load_node('52e4e647-d6ef-43c6-b8a1-adfb54bff07e')
     # sg15/Si_ONCV_PBE-1.2.upf
-    # upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
+    upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
     # # sg15/Xe_ONCV_PBE-1.2.upf
     # upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
 

--- a/examples/example_delta_factor.py
+++ b/examples/example_delta_factor.py
@@ -68,12 +68,12 @@ if __name__ == '__main__':
     #     print(node)
 
     upf_sg15 = {}
-    # # sg15/Au_ONCV_PBE-1.2.upf
-    # upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
+    # sg15/Au_ONCV_PBE-1.2.upf
+    upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
     # # sg15/O_ONCV_PBE-1.2.upf
     # upf_sg15['o'] = load_node('52e4e647-d6ef-43c6-b8a1-adfb54bff07e')
     # sg15/Si_ONCV_PBE-1.2.upf
-    upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
+    # upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
     # # sg15/Xe_ONCV_PBE-1.2.upf
     # upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
 

--- a/examples/example_delta_factor.py
+++ b/examples/example_delta_factor.py
@@ -54,42 +54,42 @@ if __name__ == '__main__':
 
     code = load_code('qe-6.6-pw@daint-mc')
 
-    upf_gbrv = {}
-    # GBRV_pbe/au_pbe_v1.uspp.F.UPF
-    upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
-    # GBRV_pbe/o_pbe_v1.2.uspp.F.UPF
-    upf_gbrv['o'] = load_node('005f1eaa-6746-41f2-8b12-38f6dabe4f61')
-    # GBRV_pbe/si_pbe_v1.uspp.F.UPF
-    upf_gbrv['si'] = load_node('15f938a1-9466-4a41-9022-4c6f06cf4e20')
-
-    for element, upf in upf_gbrv.items():
-        node = run_delta(code, upf, is_nc=False)
-        node.description = f'GBRV_pbe/{element}'
-        print(node)
+    # upf_gbrv = {}
+    # # GBRV_pbe/au_pbe_v1.uspp.F.UPF
+    # upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
+    # # GBRV_pbe/o_pbe_v1.2.uspp.F.UPF
+    # upf_gbrv['o'] = load_node('005f1eaa-6746-41f2-8b12-38f6dabe4f61')
+    # # GBRV_pbe/si_pbe_v1.uspp.F.UPF
+    # upf_gbrv['si'] = load_node('15f938a1-9466-4a41-9022-4c6f06cf4e20')
+    #
+    # for element, upf in upf_gbrv.items():
+    #     node = run_delta(code, upf, is_nc=False)
+    #     node.description = f'GBRV_pbe/{element}'
+    #     print(node)
 
     upf_sg15 = {}
-    # sg15/Au_ONCV_PBE-1.2.upf
-    upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
-    # sg15/O_ONCV_PBE-1.2.upf
-    upf_sg15['o'] = load_node('52e4e647-d6ef-43c6-b8a1-adfb54bff07e')
+    # # sg15/Au_ONCV_PBE-1.2.upf
+    # upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
+    # # sg15/O_ONCV_PBE-1.2.upf
+    # upf_sg15['o'] = load_node('52e4e647-d6ef-43c6-b8a1-adfb54bff07e')
     # sg15/Si_ONCV_PBE-1.2.upf
-    upf_sg15['si'] = load_node('f382f1ff-c44e-4381-886c-81cb5936b8a0')
-    # sg15/Xe_ONCV_PBE-1.2.upf
-    upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
+    upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
+    # # sg15/Xe_ONCV_PBE-1.2.upf
+    # upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
 
     for element, upf in upf_sg15.items():
         node = run_delta(code, upf, is_nc=True)
         node.description = f'sg15/{element}'
         print(node)
 
-    # test on lanthanides
-    upf_wt = {}
-    # WT/La.GGA-PBE-paw-v1.0.UPF
-    upf_wt['La'] = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
-    # WT/Eu.GGA-PBE-paw-v1.0.UPF
-    upf_wt['Eu'] = load_node('220a8ebd-0ac5-44f1-a6a9-0790b24965a9')
-
-    for element, upf in upf_wt.items():
-        node = run_delta(code, upf, is_nc=False)
-        node.description = f'WT/{element}-PBE'
-        print(node)
+    # # test on lanthanides
+    # upf_wt = {}
+    # # WT/La.GGA-PBE-paw-v1.0.UPF
+    # upf_wt['La'] = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
+    # # WT/Eu.GGA-PBE-paw-v1.0.UPF
+    # upf_wt['Eu'] = load_node('220a8ebd-0ac5-44f1-a6a9-0790b24965a9')
+    #
+    # for element, upf in upf_wt.items():
+    #     node = run_delta(code, upf, is_nc=False)
+    #     node.description = f'WT/{element}-PBE'
+    #     print(node)

--- a/examples/example_phonon.py
+++ b/examples/example_phonon.py
@@ -11,8 +11,9 @@ ConvergencePhononFrequencies = WorkflowFactory(
 
 
 def run_test(pw_code, ph_code, upf, dual):
-    ecutwfc = np.array(
-        [30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 90, 100, 120, 150, 200])
+    ecutwfc = np.array([30, 35, 200])
+    # ecutwfc = np.array(
+    #     [30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 90, 100, 120, 150, 200])
     ecutrho = ecutwfc * dual
     PARA_ECUTWFC_LIST = orm.List(list=list(ecutwfc))
     PARA_ECUTRHO_LIST = orm.List(list=list(ecutrho))
@@ -40,13 +41,13 @@ if __name__ == '__main__':
 
     upf_gbrv = {}
     # GBRV_pbe/si_pbe_v1.uspp.F.UPF
-    upf_gbrv['si'] = load_node('15f938a1-9466-4a41-9022-4c6f06cf4e20')
-    # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
-    upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
-    # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
-    upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
-    # GBRV_pbe/au_pbe_v1.uspp.F.UPF
-    upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
+    upf_gbrv['si'] = load_node(28953)
+    # # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
+    # upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
+    # # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
+    # upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
+    # # GBRV_pbe/au_pbe_v1.uspp.F.UPF
+    # upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
 
     for element, upf in upf_gbrv.items():
         if element == 'fe':
@@ -57,32 +58,32 @@ if __name__ == '__main__':
         node.description = f'GBRV_pbe/{element}'
         print(node)
 
-    upf_sg15 = {}
-    # sg15/Au_ONCV_PBE-1.2.upf
-    upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
-    # sg15/Si_ONCV_PBE-1.2.upf
-    upf_sg15['si'] = load_node('f382f1ff-c44e-4381-886c-81cb5936b8a0')
-    # sg15/Xe_ONCV_PBE-1.2.upf
-    upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
-    # sg15/Fe_ONCV_PBE-1.2.upf
-    upf_sg15['fe'] = load_node('12aeff74-048d-4199-b97e-2b996e7fc2d3')
-    # sg15/F_ONCV_PBE-1.2.upf
-    upf_sg15['f'] = load_node('3ef1d267-b442-43fb-bc29-7113761ca15b')
-
-    for element, upf in upf_sg15.items():
-        dual = 4.0
-        node = run_test(pw_code, ph_code, upf, dual)
-        node.description = f'sg15/{element}'
-        print(node)
-
-    # test on lanthanides
-    upf_wt = {}
-    # WT/La.GGA-PBE-paw-v1.0.UPF
-    upf_wt['La'] = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
-    # WT/Eu.GGA-PBE-paw-v1.0.UPF
-    upf_wt['Eu'] = load_node('220a8ebd-0ac5-44f1-a6a9-0790b24965a9')
-
-    for element, upf in upf_wt.items():
-        node = run_test(pw_code, ph_code, upf, dual=8.0)
-        node.description = f'WT/{element}-PBE'
-        print(node)
+    # upf_sg15 = {}
+    # # sg15/Au_ONCV_PBE-1.2.upf
+    # upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
+    # # sg15/Si_ONCV_PBE-1.2.upf
+    # upf_sg15['si'] = load_node('f382f1ff-c44e-4381-886c-81cb5936b8a0')
+    # # sg15/Xe_ONCV_PBE-1.2.upf
+    # upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
+    # # sg15/Fe_ONCV_PBE-1.2.upf
+    # upf_sg15['fe'] = load_node('12aeff74-048d-4199-b97e-2b996e7fc2d3')
+    # # sg15/F_ONCV_PBE-1.2.upf
+    # upf_sg15['f'] = load_node('3ef1d267-b442-43fb-bc29-7113761ca15b')
+    #
+    # for element, upf in upf_sg15.items():
+    #     dual = 4.0
+    #     node = run_test(pw_code, ph_code, upf, dual)
+    #     node.description = f'sg15/{element}'
+    #     print(node)
+    #
+    # # test on lanthanides
+    # upf_wt = {}
+    # # WT/La.GGA-PBE-paw-v1.0.UPF
+    # upf_wt['La'] = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
+    # # WT/Eu.GGA-PBE-paw-v1.0.UPF
+    # upf_wt['Eu'] = load_node('220a8ebd-0ac5-44f1-a6a9-0790b24965a9')
+    #
+    # for element, upf in upf_wt.items():
+    #     node = run_test(pw_code, ph_code, upf, dual=8.0)
+    #     node.description = f'WT/{element}-PBE'
+    #     print(node)

--- a/examples/example_phonon.py
+++ b/examples/example_phonon.py
@@ -1,37 +1,22 @@
 #!/usr/bin/env python
+import numpy as np
+
+from aiida import orm
 from aiida.common import AttributeDict
 from aiida.plugins import WorkflowFactory
 from aiida.engine import submit
 
-from aiida_sssp_workflow.calculations.helper_functions import helper_get_primitive_structure
-
 ConvergencePhononFrequencies = WorkflowFactory(
     'sssp_workflow.convergence.phonon_frequencies')
 
-if __name__ == '__main__':
-    from aiida import orm
-    from aiida.orm import load_code, load_node
 
-    pw_code = load_code('qe-6.6-pw@daint-mc')
-    ph_code = load_code('qe-6.6-ph@daint-mc')
+def run_test(pw_code, ph_code, upf, dual):
+    ecutwfc = np.array(
+        [30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 90, 100, 120, 150, 200])
+    ecutrho = ecutwfc * dual
+    PARA_ECUTWFC_LIST = orm.List(list=list(ecutwfc))
+    PARA_ECUTRHO_LIST = orm.List(list=list(ecutrho))
 
-    # # Silicon structure and pseudopotential
-    # upf = load_node('9d9d57fc-49e3-4e0c-8c37-4682ccc0fb51')
-
-    # Fluorine pseude
-    # upf = load_node('a1b60d81-d5a3-4ddb-a31a-d5b608c1ba52')
-
-    # gold structure and pseudopotential
-    # upf = load_node('197acb08-ff93-4e65-8de9-2242a96197b2') # NC
-    # upf = load_node('61830c2b-fa08-4e92-9571-1141ded79612')  # PAW
-
-    # Lanthanum
-    upf = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
-
-    PARA_ECUTWFC_LIST = orm.List(list=[20, 25, 200])
-    PARA_ECUTRHO_LIST = orm.List(list=[160, 200, 1600])
-
-    # minimal inputs, maximum wc
     inputs = AttributeDict({
         'pw_code': pw_code,
         'ph_code': ph_code,
@@ -39,7 +24,65 @@ if __name__ == '__main__':
         'parameters': {
             'ecutwfc_list': PARA_ECUTWFC_LIST,
             'ecutrho_list': PARA_ECUTRHO_LIST,
+            'ref_cutoff_pair': orm.List(list=[200, 200 * dual])
         },
     })
     node = submit(ConvergencePhononFrequencies, **inputs)
-    print(node)
+
+    return node
+
+
+if __name__ == '__main__':
+    from aiida.orm import load_code, load_node
+
+    pw_code = load_code('qe-6.6-pw@daint-mc')
+    ph_code = load_code('qe-6.6-ph@daint-mc')
+
+    upf_gbrv = {}
+    # GBRV_pbe/si_pbe_v1.uspp.F.UPF
+    upf_gbrv['si'] = load_node('15f938a1-9466-4a41-9022-4c6f06cf4e20')
+    # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
+    upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
+    # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
+    upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
+    # GBRV_pbe/au_pbe_v1.uspp.F.UPF
+    upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
+
+    for element, upf in upf_gbrv.items():
+        if element == 'fe':
+            dual = 12.0
+        else:
+            dual = 8.0
+        node = run_test(pw_code, ph_code, upf, dual)
+        node.description = f'GBRV_pbe/{element}'
+        print(node)
+
+    upf_sg15 = {}
+    # sg15/Au_ONCV_PBE-1.2.upf
+    upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
+    # sg15/Si_ONCV_PBE-1.2.upf
+    upf_sg15['si'] = load_node('f382f1ff-c44e-4381-886c-81cb5936b8a0')
+    # sg15/Xe_ONCV_PBE-1.2.upf
+    upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
+    # sg15/Fe_ONCV_PBE-1.2.upf
+    upf_sg15['fe'] = load_node('12aeff74-048d-4199-b97e-2b996e7fc2d3')
+    # sg15/F_ONCV_PBE-1.2.upf
+    upf_sg15['f'] = load_node('3ef1d267-b442-43fb-bc29-7113761ca15b')
+
+    for element, upf in upf_sg15.items():
+        dual = 4.0
+        node = run_test(pw_code, ph_code, upf, dual)
+        node.description = f'sg15/{element}'
+        print(node)
+
+    # test on lanthanides
+    upf_wt = {}
+    # WT/La.GGA-PBE-paw-v1.0.UPF
+    upf_wt['La'] = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
+    # WT/Eu.GGA-PBE-paw-v1.0.UPF
+    upf_wt['Eu'] = load_node('220a8ebd-0ac5-44f1-a6a9-0790b24965a9')
+
+    for element, upf in upf_wt.items():
+        node = run_test(pw_code, ph_code, upf, dual=8.0)
+        node.description = f'WT/{element}-PBE'
+        print(node)

--- a/examples/example_phonon.py
+++ b/examples/example_phonon.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
 
     upf_sg15 = {}
     # # sg15/Au_ONCV_PBE-1.2.upf
-    # upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
+    upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
     # sg15/Si_ONCV_PBE-1.2.upf
     upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
     # # sg15/Xe_ONCV_PBE-1.2.upf

--- a/examples/example_phonon.py
+++ b/examples/example_phonon.py
@@ -39,42 +39,42 @@ if __name__ == '__main__':
     pw_code = load_code('qe-6.6-pw@daint-mc')
     ph_code = load_code('qe-6.6-ph@daint-mc')
 
-    upf_gbrv = {}
-    # GBRV_pbe/si_pbe_v1.uspp.F.UPF
-    upf_gbrv['si'] = load_node(28953)
-    # # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
-    # upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
-    # # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
-    # upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
-    # # GBRV_pbe/au_pbe_v1.uspp.F.UPF
-    # upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
+    # upf_gbrv = {}
+    # # GBRV_pbe/si_pbe_v1.uspp.F.UPF
+    # # upf_gbrv['si'] = load_node(28953)
+    # # # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
+    # # upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
+    # # # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
+    # # upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
+    # # # GBRV_pbe/au_pbe_v1.uspp.F.UPF
+    # # upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
+    #
+    # for element, upf in upf_gbrv.items():
+    #     if element == 'fe':
+    #         dual = 12.0
+    #     else:
+    #         dual = 8.0
+    #     node = run_test(pw_code, ph_code, upf, dual)
+    #     node.description = f'GBRV_pbe/{element}'
+    #     print(node)
 
-    for element, upf in upf_gbrv.items():
-        if element == 'fe':
-            dual = 12.0
-        else:
-            dual = 8.0
-        node = run_test(pw_code, ph_code, upf, dual)
-        node.description = f'GBRV_pbe/{element}'
-        print(node)
-
-    # upf_sg15 = {}
+    upf_sg15 = {}
     # # sg15/Au_ONCV_PBE-1.2.upf
     # upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
-    # # sg15/Si_ONCV_PBE-1.2.upf
-    # upf_sg15['si'] = load_node('f382f1ff-c44e-4381-886c-81cb5936b8a0')
+    # sg15/Si_ONCV_PBE-1.2.upf
+    upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
     # # sg15/Xe_ONCV_PBE-1.2.upf
     # upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
     # # sg15/Fe_ONCV_PBE-1.2.upf
     # upf_sg15['fe'] = load_node('12aeff74-048d-4199-b97e-2b996e7fc2d3')
     # # sg15/F_ONCV_PBE-1.2.upf
     # upf_sg15['f'] = load_node('3ef1d267-b442-43fb-bc29-7113761ca15b')
-    #
-    # for element, upf in upf_sg15.items():
-    #     dual = 4.0
-    #     node = run_test(pw_code, ph_code, upf, dual)
-    #     node.description = f'sg15/{element}'
-    #     print(node)
+
+    for element, upf in upf_sg15.items():
+        dual = 4.0
+        node = run_test(pw_code, ph_code, upf, dual)
+        node.description = f'sg15/{element}'
+        print(node)
     #
     # # test on lanthanides
     # upf_wt = {}

--- a/examples/example_pressure.py
+++ b/examples/example_pressure.py
@@ -12,8 +12,7 @@ ConvergencePressureWorkChain = WorkflowFactory(
 
 
 def run_test(code, upf, dual):
-    ecutwfc = np.array(
-        [30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 90, 100, 120, 150, 200])
+    ecutwfc = np.array([30, 35, 200])
     ecutrho = ecutwfc * dual
     PARA_ECUTWFC_LIST = orm.List(list=list(ecutwfc))
     PARA_ECUTRHO_LIST = orm.List(list=list(ecutrho))
@@ -39,13 +38,13 @@ if __name__ == '__main__':
 
     upf_gbrv = {}
     # GBRV_pbe/si_pbe_v1.uspp.F.UPF
-    upf_gbrv['si'] = load_node('15f938a1-9466-4a41-9022-4c6f06cf4e20')
-    # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
-    upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
-    # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
-    upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
-    # GBRV_pbe/au_pbe_v1.uspp.F.UPF
-    upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
+    upf_gbrv['si'] = load_node(28953)
+    # # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
+    # upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
+    # # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
+    # upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
+    # # GBRV_pbe/au_pbe_v1.uspp.F.UPF
+    # upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
 
     for element, upf in upf_gbrv.items():
         if element == 'fe':
@@ -56,32 +55,32 @@ if __name__ == '__main__':
         node.description = f'GBRV_pbe/{element}'
         print(node)
 
-    upf_sg15 = {}
-    # sg15/Au_ONCV_PBE-1.2.upf
-    upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
-    # sg15/Si_ONCV_PBE-1.2.upf
-    upf_sg15['si'] = load_node('f382f1ff-c44e-4381-886c-81cb5936b8a0')
-    # sg15/Xe_ONCV_PBE-1.2.upf
-    upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
-    # sg15/Fe_ONCV_PBE-1.2.upf
-    upf_sg15['fe'] = load_node('12aeff74-048d-4199-b97e-2b996e7fc2d3')
-    # sg15/F_ONCV_PBE-1.2.upf
-    upf_sg15['f'] = load_node('3ef1d267-b442-43fb-bc29-7113761ca15b')
-
-    for element, upf in upf_sg15.items():
-        dual = 4.0
-        node = run_test(code, upf, dual)
-        node.description = f'sg15/{element}'
-        print(node)
-
-    # test on lanthanides
-    upf_wt = {}
-    # WT/La.GGA-PBE-paw-v1.0.UPF
-    upf_wt['La'] = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
-    # WT/Eu.GGA-PBE-paw-v1.0.UPF
-    upf_wt['Eu'] = load_node('220a8ebd-0ac5-44f1-a6a9-0790b24965a9')
-
-    for element, upf in upf_wt.items():
-        node = run_test(code, upf, dual=8.0)
-        node.description = f'WT/{element}-PBE'
-        print(node)
+    # upf_sg15 = {}
+    # # sg15/Au_ONCV_PBE-1.2.upf
+    # upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
+    # # sg15/Si_ONCV_PBE-1.2.upf
+    # upf_sg15['si'] = load_node('f382f1ff-c44e-4381-886c-81cb5936b8a0')
+    # # sg15/Xe_ONCV_PBE-1.2.upf
+    # upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
+    # # sg15/Fe_ONCV_PBE-1.2.upf
+    # upf_sg15['fe'] = load_node('12aeff74-048d-4199-b97e-2b996e7fc2d3')
+    # # sg15/F_ONCV_PBE-1.2.upf
+    # upf_sg15['f'] = load_node('3ef1d267-b442-43fb-bc29-7113761ca15b')
+    #
+    # for element, upf in upf_sg15.items():
+    #     dual = 4.0
+    #     node = run_test(code, upf, dual)
+    #     node.description = f'sg15/{element}'
+    #     print(node)
+    #
+    # # test on lanthanides
+    # upf_wt = {}
+    # # WT/La.GGA-PBE-paw-v1.0.UPF
+    # upf_wt['La'] = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
+    # # WT/Eu.GGA-PBE-paw-v1.0.UPF
+    # upf_wt['Eu'] = load_node('220a8ebd-0ac5-44f1-a6a9-0790b24965a9')
+    #
+    # for element, upf in upf_wt.items():
+    #     node = run_test(code, upf, dual=8.0)
+    #     node.description = f'WT/{element}-PBE'
+    #     print(node)

--- a/examples/example_pressure.py
+++ b/examples/example_pressure.py
@@ -5,6 +5,8 @@ from aiida import orm
 from aiida.common import AttributeDict
 from aiida.plugins import WorkflowFactory
 
+from aiida_sssp_workflow.workflows.convergence.pressure import helper_get_v0_b0_b1
+
 from aiida.engine import run_get_node, submit
 
 ConvergencePressureWorkChain = WorkflowFactory(
@@ -17,13 +19,22 @@ def run_test(code, upf, dual):
     PARA_ECUTWFC_LIST = orm.List(list=list(ecutwfc))
     PARA_ECUTRHO_LIST = orm.List(list=list(ecutrho))
 
+    element = upf.element
+    res = helper_get_v0_b0_b1(orm.Str(element))
+    v0_b0_b1 = {
+        'V0': res['V0'].value,
+        'B0': res['B0'].value,
+        'B1': res['B1'].value,
+    }
+
     inputs = AttributeDict({
         'code': code,
         'pseudo': upf,
         'parameters': {
             'ecutwfc_list': PARA_ECUTWFC_LIST,
             'ecutrho_list': PARA_ECUTRHO_LIST,
-            'ref_cutoff_pair': orm.List(list=[200, 200 * dual])
+            'ref_cutoff_pair': orm.List(list=[200, 200 * dual]),
+            'v0_b0_b1': orm.Dict(dict=v0_b0_b1),
         },
     })
     node = submit(ConvergencePressureWorkChain, **inputs)
@@ -57,7 +68,7 @@ if __name__ == '__main__':
 
     upf_sg15 = {}
     # # sg15/Au_ONCV_PBE-1.2.upf
-    # upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
+    upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
     # sg15/Si_ONCV_PBE-1.2.upf
     upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
     # # sg15/Xe_ONCV_PBE-1.2.upf

--- a/examples/example_pressure.py
+++ b/examples/example_pressure.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+import numpy as np
+
+from aiida import orm
 from aiida.common import AttributeDict
 from aiida.plugins import WorkflowFactory
 
@@ -7,27 +10,13 @@ from aiida.engine import run_get_node, submit
 ConvergencePressureWorkChain = WorkflowFactory(
     'sssp_workflow.convergence.pressure')
 
-if __name__ == '__main__':
-    from aiida import orm
-    from aiida.orm import load_code, load_node
 
-    code = load_code('qe-6.6-pw@daint-mc')
-
-    # # Silicon structure and pseudopotential
-    # upf = load_node('9d9d57fc-49e3-4e0c-8c37-4682ccc0fb51')
-
-    # Fluorine pseude
-    upf = load_node('a1b60d81-d5a3-4ddb-a31a-d5b608c1ba52')
-
-    # gold structure and pseudopotential
-    # upf = load_node('197acb08-ff93-4e65-8de9-2242a96197b2') # NC
-    # upf = load_node('61830c2b-fa08-4e92-9571-1141ded79612')  # PAW
-
-    # Lanthanum
-    # upf = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
-
-    PARA_ECUTWFC_LIST = orm.List(list=[20, 25, 200])
-    PARA_ECUTRHO_LIST = orm.List(list=[160, 200, 1600])
+def run_test(code, upf, dual):
+    ecutwfc = np.array(
+        [30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 90, 100, 120, 150, 200])
+    ecutrho = ecutwfc * dual
+    PARA_ECUTWFC_LIST = orm.List(list=list(ecutwfc))
+    PARA_ECUTRHO_LIST = orm.List(list=list(ecutrho))
 
     inputs = AttributeDict({
         'code': code,
@@ -35,7 +24,64 @@ if __name__ == '__main__':
         'parameters': {
             'ecutwfc_list': PARA_ECUTWFC_LIST,
             'ecutrho_list': PARA_ECUTRHO_LIST,
+            'ref_cutoff_pair': orm.List(list=[200, 200 * dual])
         },
     })
     node = submit(ConvergencePressureWorkChain, **inputs)
-    print(node)
+
+    return node
+
+
+if __name__ == '__main__':
+    from aiida.orm import load_code, load_node
+
+    code = load_code('qe-6.6-pw@daint-mc')
+
+    upf_gbrv = {}
+    # GBRV_pbe/si_pbe_v1.uspp.F.UPF
+    upf_gbrv['si'] = load_node('15f938a1-9466-4a41-9022-4c6f06cf4e20')
+    # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
+    upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
+    # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
+    upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
+    # GBRV_pbe/au_pbe_v1.uspp.F.UPF
+    upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
+
+    for element, upf in upf_gbrv.items():
+        if element == 'fe':
+            dual = 12.0
+        else:
+            dual = 8.0
+        node = run_test(code, upf, dual)
+        node.description = f'GBRV_pbe/{element}'
+        print(node)
+
+    upf_sg15 = {}
+    # sg15/Au_ONCV_PBE-1.2.upf
+    upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
+    # sg15/Si_ONCV_PBE-1.2.upf
+    upf_sg15['si'] = load_node('f382f1ff-c44e-4381-886c-81cb5936b8a0')
+    # sg15/Xe_ONCV_PBE-1.2.upf
+    upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
+    # sg15/Fe_ONCV_PBE-1.2.upf
+    upf_sg15['fe'] = load_node('12aeff74-048d-4199-b97e-2b996e7fc2d3')
+    # sg15/F_ONCV_PBE-1.2.upf
+    upf_sg15['f'] = load_node('3ef1d267-b442-43fb-bc29-7113761ca15b')
+
+    for element, upf in upf_sg15.items():
+        dual = 4.0
+        node = run_test(code, upf, dual)
+        node.description = f'sg15/{element}'
+        print(node)
+
+    # test on lanthanides
+    upf_wt = {}
+    # WT/La.GGA-PBE-paw-v1.0.UPF
+    upf_wt['La'] = load_node('b2880763-579c-4f6d-8803-2c77f4fb10e8')
+    # WT/Eu.GGA-PBE-paw-v1.0.UPF
+    upf_wt['Eu'] = load_node('220a8ebd-0ac5-44f1-a6a9-0790b24965a9')
+
+    for element, upf in upf_wt.items():
+        node = run_test(code, upf, dual=8.0)
+        node.description = f'WT/{element}-PBE'
+        print(node)

--- a/examples/example_pressure.py
+++ b/examples/example_pressure.py
@@ -57,9 +57,9 @@ if __name__ == '__main__':
 
     upf_sg15 = {}
     # # sg15/Au_ONCV_PBE-1.2.upf
-    upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
+    # upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
     # sg15/Si_ONCV_PBE-1.2.upf
-    # upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
+    upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
     # # sg15/Xe_ONCV_PBE-1.2.upf
     # upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
     # # sg15/Fe_ONCV_PBE-1.2.upf

--- a/examples/example_pressure.py
+++ b/examples/example_pressure.py
@@ -36,42 +36,42 @@ if __name__ == '__main__':
 
     code = load_code('qe-6.6-pw@daint-mc')
 
-    upf_gbrv = {}
-    # GBRV_pbe/si_pbe_v1.uspp.F.UPF
-    upf_gbrv['si'] = load_node(28953)
-    # # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
-    # upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
-    # # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
-    # upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
-    # # GBRV_pbe/au_pbe_v1.uspp.F.UPF
-    # upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
+    # upf_gbrv = {}
+    # # GBRV_pbe/si_pbe_v1.uspp.F.UPF
+    # # upf_gbrv['si'] = load_node(28953)
+    # # # GBRV_pbe/fe_pbe_v1.5.uspp.F.UPF
+    # # upf_gbrv['fe'] = load_node('cdd71d89-6ff8-4f54-a996-df0d37b39489')
+    # # # GBRV_pbe/f_pbe_v1.4.uspp.F.UPF
+    # # upf_gbrv['f'] = load_node('5963dba6-e1e9-4f8a-92c2-de84219f393f')
+    # # # GBRV_pbe/au_pbe_v1.uspp.F.UPF
+    # # upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
+    #
+    # for element, upf in upf_gbrv.items():
+    #     if element == 'fe':
+    #         dual = 12.0
+    #     else:
+    #         dual = 8.0
+    #     node = run_test(code, upf, dual)
+    #     node.description = f'GBRV_pbe/{element}'
+    #     print(node)
 
-    for element, upf in upf_gbrv.items():
-        if element == 'fe':
-            dual = 12.0
-        else:
-            dual = 8.0
-        node = run_test(code, upf, dual)
-        node.description = f'GBRV_pbe/{element}'
-        print(node)
-
-    # upf_sg15 = {}
+    upf_sg15 = {}
     # # sg15/Au_ONCV_PBE-1.2.upf
-    # upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
-    # # sg15/Si_ONCV_PBE-1.2.upf
-    # upf_sg15['si'] = load_node('f382f1ff-c44e-4381-886c-81cb5936b8a0')
+    upf_sg15['au'] = load_node('b9583fdd-905e-41c1-b5b9-1dfb9e15772d')
+    # sg15/Si_ONCV_PBE-1.2.upf
+    # upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
     # # sg15/Xe_ONCV_PBE-1.2.upf
     # upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
     # # sg15/Fe_ONCV_PBE-1.2.upf
     # upf_sg15['fe'] = load_node('12aeff74-048d-4199-b97e-2b996e7fc2d3')
     # # sg15/F_ONCV_PBE-1.2.upf
     # upf_sg15['f'] = load_node('3ef1d267-b442-43fb-bc29-7113761ca15b')
-    #
-    # for element, upf in upf_sg15.items():
-    #     dual = 4.0
-    #     node = run_test(code, upf, dual)
-    #     node.description = f'sg15/{element}'
-    #     print(node)
+
+    for element, upf in upf_sg15.items():
+        dual = 4.0
+        node = run_test(code, upf, dual)
+        node.description = f'sg15/{element}'
+        print(node)
     #
     # # test on lanthanides
     # upf_wt = {}


### PR DESCRIPTION
This gonna to fix 
- #12: structure in convergence test workflow use the primitive one 
- #13: use the same default smearing width for all the in practice workflow
- #16: refactoring the examples and run tests in practice
- #17: Put hard code parameters at the beginning of the workflow class
- #18: put Birch Murnaghan fit calculation into EOS workflow
- #20: turn on the tstress = true in every scf running to make caching mechanism widely available
- #19: In pressure converge use BM-fit results of its specific pseudopotential