### PR TITLE
convergence engine used for all convergence workflow

### DIFF
--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -1,29 +1,24 @@
-name: Publish on PyPI
+name: Publish Python distributions 📦 to PyPI and TestPyPI
 
-on:
-  push:
-    tags:
-      # After vMajor.Minor.Patch _anything_ is allowed (without "/") !
-      - v[0-9]+.[0-9]+.[0-9]+*
+on: push
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.repository == 'aiidateam/aiida-sssp-workflow' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Upgrade setuptools and install package
       run: |
-        python -m pip install --upgrade pip setuptools
-        python -m pip install -e .
+        python -m pip install --upgrade pip
+        pip install twine
 
     - name: Assert package version
       env:
@@ -31,10 +26,23 @@ jobs:
       run: python ./.github/check_version.py
 
     - name: Build source distribution
-      run: python ./setup.py sdist
-
-    - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
       with:
-        user: __token__
-        password: ${{ secrets.pypi_token }}
+        python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39'
+        build-requirements: 'cython numpy'
+        pip-wheel-args: '-w ./wheelhouse --no-deps'
+
+    - name: Publish distribution 📦 to Test PyPI
+      env:
+        TWINE_USERNAME: '__token__'
+        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      run: |
+        twine upload --repository-url https://test.pypi.org/legacy/ wheelhouse/*-manylinux*.whl
+
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      env:
+        TWINE_USERNAME: '__token__'
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        twine upload wheelhouse/*-manylinux*.whl

--- a/aiida_sssp_workflow/__init__.py
+++ b/aiida_sssp_workflow/__init__.py
@@ -4,4 +4,4 @@ aiida_sssp_workflow
 SSSP verification workflows
 """
 
-__version__ = "0.1.0a0"
+__version__ = "0.1.0a1"

--- a/aiida_sssp_workflow/workflows/bands.py
+++ b/aiida_sssp_workflow/workflows/bands.py
@@ -88,6 +88,20 @@ class BandsWorkChain(WorkChain):
                    valid_type=orm.Dict,
                    default=PW_PARAS,
                    help='parameters for pw.x.')
+        spec.input(
+            'parameters.ecutwfc',
+            valid_type=(orm.Float, orm.Int),
+            required=False,
+            help=
+            'The ecutwfc set for both atom and bulk calculation. Please also set ecutrho if ecutwfc is set.'
+        )
+        spec.input(
+            'parameters.ecutrho',
+            valid_type=(orm.Float, orm.Int),
+            required=False,
+            help=
+            'The ecutrho set for both atom and bulk calculation.  Please also set ecutwfc if ecutrho is set.'
+        )
         spec.input('parameters.scf_kpoints_distance',
                    valid_type=orm.Float,
                    default=lambda: orm.Float(0.1),
@@ -137,6 +151,17 @@ class BandsWorkChain(WorkChain):
                                           self.inputs.parameters.pw.get_dict())
         pw_bands_parameters['SYSTEM'].pop(
             'nbnd', None)  # Since nbnd can not sit with nband_factor
+
+        if self.inputs.parameters.ecutwfc and self.inputs.parameters.ecutrho:
+            parameters = {
+                'SYSTEM': {
+                    'ecutwfc': self.inputs.parameters.ecutwfc,
+                    'ecutrho': self.inputs.parameters.ecutrho,
+                },
+            }
+            pw_scf_parameters = update_dict(pw_scf_parameters, parameters)
+            pw_bands_parameters = update_dict(pw_bands_parameters, parameters)
+
         self.ctx.pw_scf_parameters = orm.Dict(dict=pw_scf_parameters)
         self.ctx.pw_bands_parameters = orm.Dict(dict=pw_bands_parameters)
 

--- a/aiida_sssp_workflow/workflows/convergence/bands.py
+++ b/aiida_sssp_workflow/workflows/convergence/bands.py
@@ -3,12 +3,13 @@
 Convergence test on bands of a given pseudopotential
 """
 from aiida.common import AttributeDict
-from aiida.engine import WorkChain, ToContext, append_
+from aiida.engine import workfunction
 from aiida import orm
 from aiida.plugins import WorkflowFactory
 
-from aiida_sssp_workflow.utils import update_dict
-from ..helper import get_pw_inputs_from_pseudo
+from aiida_sssp_workflow.utils import update_dict, NONMETAL_ELEMENTS
+from aiida_sssp_workflow.calculations.calculate_bands_distance import calculate_bands_distance
+from .base import BaseConvergenceWorkChain
 
 BandsWorkChain = WorkflowFactory('sssp_workflow.bands')
 
@@ -23,17 +24,46 @@ PARA_ECUTRHO_LIST = lambda: orm.List(list=[
 ])
 
 
-class ConvergenceBandsWorkChain(WorkChain):
+@workfunction
+def helper_cohesive_energy_difference(input_band_structure: orm.BandsData,
+                                      ref_band_structure: orm.BandsData,
+                                      input_band_parameters: orm.Dict,
+                                      ref_band_parameters: orm.Dict,
+                                      smearing: orm.Float, is_metal: orm.Bool):
+    res = calculate_bands_distance(input_band_structure,
+                                   ref_band_structure,
+                                   input_band_parameters,
+                                   ref_band_parameters,
+                                   smearing=smearing,
+                                   is_metal=is_metal)
+
+    return orm.Dict(
+        dict={
+            'eta_v': res.get('eta_v', None).value,
+            'eta_10': res.get('eta_10', None).value,
+            'max_diff_v': res.get('max_diff_v', None).value,
+            'max_diff_10': res.get('max_diff_10', None).value,
+        }).store()
+
+
+class ConvergenceBandsWorkChain(BaseConvergenceWorkChain):
     """WorkChain to converge test on cohisive energy of input structure"""
 
+    # hard code parameters of evaluate workflow
     _DEGUASS = 0.00735
     _OCCUPATIONS = 'smearing'
     _SMEARING = 'marzari-vanderbilt'
     _CONV_THR = 1e-10
     _SCF_KDISTANCE = 0.15
     _BAND_KDISTANCE = 0.20
+    _ININ_NBND_FACTOR = 2.0
 
     _RY_TO_EV = 13.6056980659
+
+    # hard code parameters of convergence workflow
+    _TOLERANCE = 1e-1
+    _CONV_THR_CONV = 1e-1
+    _CONV_WINDOW = 3
 
     @classmethod
     def define(cls, spec):
@@ -41,75 +71,38 @@ class ConvergenceBandsWorkChain(WorkChain):
         spec.input('code',
                    valid_type=orm.Code,
                    help='The `pw.x` code use for the `PwCalculation`.')
-        spec.input('pseudo',
-                   valid_type=orm.UpfData,
-                   required=True,
-                   help='Pseudopotential to be verified')
-        spec.input('options',
-                   valid_type=orm.Dict,
-                   required=False,
-                   help='Optional `options` to use for the `PwCalculations`.')
-        spec.input_namespace('parameters', help='Para')
-        spec.input('parameters.ecutrho_list',
-                   valid_type=orm.List,
-                   default=lambda: PARA_ECUTRHO_LIST,
-                   help='dual value for ecutrho list.')
-        spec.input('parameters.ecutwfc_list',
-                   valid_type=orm.List,
-                   default=PARA_ECUTWFC_LIST,
-                   help='list of ecutwfc evaluate list.')
-        spec.input('parameters.ref_cutoff_pair',
-                   valid_type=orm.List,
-                   required=True,
-                   default=lambda: orm.List(list=[200, 1600]),
-                   help='ecutwfc/ecutrho pair for reference calculation.')
-        spec.outline(
-            cls.setup,
-            cls.validate_structure,
-            cls.run_ref,
-            cls.run_all,
-            cls.results,
-        )
-        spec.output(
-            'output_parameters',
-            valid_type=orm.Dict,
-            required=True,
-            help=
-            'The output parameters include cohesive energy of the structure.')
-        spec.output(
-            'xy_data',
-            valid_type=orm.XyData,
-            required=True,
-            help='The output XY data for plot use; the x axis is ecutwfc.')
-        spec.exit_code(
-            400,
-            'ERROR_SUB_PROCESS_FAILED',
-            message='The sub processes {pk} did not finish successfully.')
 
-    def setup(self):
-        self.ctx.ecutwfc_list = self.inputs.parameters.ecutwfc_list.get_list()
-        self.ctx.ecutrho_list = self.inputs.parameters.ecutrho_list.get_list()
-        if not len(self.ctx.ecutwfc_list) == len(self.ctx.ecutrho_list):
-            return self.exit_codes.ERROR_DIFFERENT_SIZE_OF_ECUTOFF_PAIRS
+    def init_step(self):
+        element = self.inputs.pseudo.element
+        self.ctx.is_metal = element not in NONMETAL_ELEMENTS
 
-    def validate_structure(self):
-        res = get_pw_inputs_from_pseudo(pseudo=self.inputs.pseudo)
+    def get_create_process(self):
+        return BandsWorkChain
 
-        self.ctx.structure = res['structure']
-        self.ctx.pseudos = res['pseudos']
-        self.ctx.base_pw_parameters = res['base_pw_parameters']
+    def get_evaluate_process(self):
+        return helper_cohesive_energy_difference
 
-    def get_inputs(self,
-                   ecutwfc,
-                   ecutrho,
-                   nbands_factor: orm.Float = orm.Float(2.0)):
+    def get_parsed_results(self):
+        return {
+            'eta_v': ('The difference eta of valence bands', 'dl'),
+            'eta_10':
+            ('The difference eta of valence bands and conduct bands up to 10.0eV',
+             'dl'),
+            'max_diff_v': ('The max difference of valence bands', 'dl'),
+            'max_diff_10':
+            ('The max difference of valence bands and conduct bands up to 10.0eV',
+             'dl'),
+        }
+
+    def get_converge_y(self):
+        return 'eta_v', 'dl'
+
+    def get_create_process_inputs(self):
         _PW_PARAS = {   # pylint: disable=invalid-name
             'SYSTEM': {
                 'degauss': self._DEGUASS,
                 'occupations': self._OCCUPATIONS,
                 'smearing': self._SMEARING,
-                'ecutrho': ecutrho,
-                'ecutwfc': ecutwfc,
             },
             'ELECTRONS': {
                 'conv_thr': self._CONV_THR,
@@ -129,131 +122,28 @@ class ConvergenceBandsWorkChain(WorkChain):
                 'bands_kpoints_distance':
                 orm.Float(self._BAND_KDISTANCE),
                 'nbands_factor':
-                nbands_factor,
+                orm.Float(self._ININ_NBND_FACTOR)
             },
         })
 
         return inputs
 
-    def run_ref(self):
-        """
-        Running the calculation for the reference point
-        hard code to 200Ry at the moment
-        """
-        cutoff_pair = self.inputs.parameters.ref_cutoff_pair.get_list()
-        ecutwfc = cutoff_pair[0]
-        ecutrho = cutoff_pair[1]
-        inputs = self.get_inputs(ecutwfc, ecutrho)
-
-        running = self.submit(BandsWorkChain, **inputs)
-
-        self.report(f'launching reference BandsWorkChain<{running.pk}>.')
-
-        return ToContext(ref_workchain=running)
-
-    def run_all(self):
-        """
-        Running the calculation for other points
-        """
+    def get_evaluate_process_inputs(self):
         ref_workchain = self.ctx.ref_workchain
 
-        if not ref_workchain.is_finished_ok:
-            self.report(
-                f'Reference run of BandsWorkChain failed with exit status {ref_workchain.exit_status}'
-            )
-            return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(
-                pk=ref_workchain.pk)
-
-        self.ctx.ref_bands = {
-            'bands': ref_workchain.outputs.band_structure,
-            'parameters': ref_workchain.outputs.band_parameters,
+        res = {
+            'ref_band_parameters': ref_workchain.outputs.band_parameters,
+            'ref_band_structure': ref_workchain.outputs.band_structure,
+            'smearing': orm.Float(self._DEGUASS * self._RY_TO_EV),
+            'is_metal': orm.Bool(self.ctx.is_metal),
         }
-        nbands_factor = ref_workchain.outputs.nbands_factor
 
-        for ecutwfc, ecutrho in zip(self.ctx.ecutwfc_list,
-                                    self.ctx.ecutrho_list):
-            inputs = self.get_inputs(ecutwfc, ecutrho, nbands_factor)
+        return res
 
-            workchain = self.submit(BandsWorkChain, **inputs)
-            self.report(
-                f'submitting bands evaluation {workchain.pk} on ecutwfc={ecutwfc} ecutrho={ecutrho}.'
-            )
-            self.to_context(children=append_(workchain))
-
-    def results(self):
-        """
-        doc
-        """
-        import numpy as np
-        from aiida_sssp_workflow.utils import NONMETAL_ELEMENTS
-        from aiida_sssp_workflow.calculations.calculate_bands_distance import calculate_bands_distance
-
-        pks = [
-            child.pk for child in self.ctx.children if not child.is_finished_ok
-        ]
-        if pks:
-            # TODO failed only when points are not enough < 80%
-            return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(pk=pks)
-
-        success_child = [
-            child for child in self.ctx.children if child.is_finished_ok
-        ]
-
-        eta_v_list = []
-        eta_10_list = []
-        max_diff_v_list = []
-        max_diff_10_list = []
-        ecutwfc_list = []
-        ecutrho_list = []
-
-        ref_bands = self.ctx.ref_bands
-        for child in success_child:
-            ecutwfc = child.inputs.parameters__pw['SYSTEM']['ecutwfc']
-            ecutrho = child.inputs.parameters__pw['SYSTEM']['ecutrho']
-            bands = {
-                'bands': child.outputs.band_structure,
-                'parameters': child.outputs.band_parameters,
-            }
-
-            ecutwfc_list.append(ecutwfc)
-            ecutrho_list.append(ecutrho)
-
-            smearing = orm.Float(0.00735 * self._RY_TO_EV)
-            if self.inputs.pseudo.element in NONMETAL_ELEMENTS:
-                is_metal = orm.Bool(False)
-            else:
-                is_metal = orm.Bool(True)
-            res = calculate_bands_distance(bands['bands'],
-                                           ref_bands['bands'],
-                                           bands['parameters'],
-                                           ref_bands['parameters'],
-                                           smearing=smearing,
-                                           is_metal=is_metal)
-
-            self.report(f'The bands distance results are '
-                        f'eta_v={res.get("eta_v", None).value};'
-                        f'eta_10={res.get("eta_10", None).value}; '
-                        f'max_diff_v={res.get("max_diff_v", None).value}; '
-                        f'max_diff_10={res.get("max_diff_10", None).value}.')
-            eta_v_list.append(res.get('eta_v', None).value)
-            eta_10_list.append(res.get('eta_10', None).value)
-            max_diff_v_list.append(res.get('max_diff_v', None).value)
-            max_diff_10_list.append(res.get('max_diff_10', None).value)
-
-        xy_data = orm.XyData()
-        xy_data.set_x(np.array(ecutwfc_list), 'wavefunction cutoff', 'Rydberg')
-        xy_data.set_y(np.array(eta_v_list), 'eta_v', '(dl)')
-
-        output_parameters = orm.Dict(
+    def get_output_input_mapping(self):
+        res = orm.Dict(
             dict={
-                'ecutwfc_list': ecutwfc_list,
-                'ecutrho_list': ecutrho_list,
-                'eta_v_list': eta_v_list,
-                'eta_10_list': eta_10_list,
-                'max_diff_v_list': max_diff_v_list,
-                'max_diff_10_list': max_diff_10_list,
-                'cutoff_unit': 'Ry',
-                'relative_unit': '(dl)',
+                'band_parameters': 'input_band_parameters',
+                'band_structure': 'input_band_structure',
             })
-        self.out('output_parameters', output_parameters.store())
-        self.out('xy_data', xy_data.store())
+        return res

--- a/aiida_sssp_workflow/workflows/convergence/base.py
+++ b/aiida_sssp_workflow/workflows/convergence/base.py
@@ -1,0 +1,358 @@
+# -*- coding: utf-8 -*-
+"""
+The base convergence WorkChain
+"""
+from abc import ABCMeta, abstractmethod
+import typing as ty
+
+from aiida_tools.process_inputs import get_fullname
+
+from aiida.engine import WorkChain, ToContext
+from aiida import orm
+from aiida.plugins import WorkflowFactory
+
+from aiida_sssp_workflow.workflows.convergence.engine import TwoInputsTwoFactorsConvergence
+from ..helper import get_pw_inputs_from_pseudo
+
+CreateEvaluateWorkChain = WorkflowFactory('optimize.wrappers.create_evaluate')
+OptimizationWorkChain = WorkflowFactory('optimize.optimize')
+
+PARA_ECUTWFC_LIST = lambda: orm.List(list=[
+    20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 110,
+    120, 130, 140, 160, 180, 200
+])
+
+PARA_ECUTRHO_LIST = lambda: orm.List(list=[
+    160, 200, 240, 280, 320, 360, 400, 440, 480, 520, 560, 600, 640, 680, 720,
+    760, 800, 880, 960, 1040, 1120, 1280, 1440, 1600
+])
+
+
+class BaseConvergenceWorkChain(WorkChain):
+    """Meta WorkChain to run convergence test"""
+    __metaclass__ = ABCMeta
+
+    # hard code parameters of convergence workflow
+    # can be(should be) overwrite by subclass
+    _TOLERANCE = 1e-1
+    _CONV_THR_CONV = 1e-1
+    _CONV_WINDOW = 3
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input('pseudo',
+                   valid_type=orm.UpfData,
+                   required=True,
+                   help='Pseudopotential to be verified')
+        spec.input('options',
+                   valid_type=orm.Dict,
+                   required=False,
+                   help='Optional `options` to use for the `PwCalculations`.')
+        spec.input_namespace('parameters', help='Para')
+        spec.input('parameters.ecutrho_list',
+                   valid_type=orm.List,
+                   default=PARA_ECUTRHO_LIST,
+                   help='dual value for ecutrho list.')
+        spec.input('parameters.ecutwfc_list',
+                   valid_type=orm.List,
+                   default=PARA_ECUTWFC_LIST,
+                   help='list of ecutwfc evaluate list.')
+        spec.input('parameters.ref_cutoff_pair',
+                   valid_type=orm.List,
+                   required=True,
+                   default=lambda: orm.List(list=[200, 1600]),
+                   help='ecutwfc/ecutrho pair for reference calculation.')
+        spec.outline(
+            cls.init_step,
+            cls.setup,
+            cls.validate_structure,
+            cls.run_ref,
+            cls.run_all,
+            cls.results,
+            cls.final_step,
+        )
+        spec.output(
+            'output_parameters',
+            valid_type=orm.Dict,
+            required=True,
+            help='The output parameters include results of all calculations.')
+        spec.output(
+            'xy_data_ecutwfc',
+            valid_type=orm.XyData,
+            required=True,
+            help='The output XY data for plot use; the x axis is ecutwfc.')
+        spec.output(
+            'xy_data_ecutrho',
+            valid_type=orm.XyData,
+            required=True,
+            help='The output XY data for plot use; the x axis is ecutrho.')
+        spec.output('output_convergence_parameters',
+                    valid_type=orm.Dict,
+                    required=False,
+                    help='The result point of convergence test.')
+        spec.exit_code(
+            400,
+            'ERROR_SUB_PROCESS_FAILED',
+            message='The sub processes {pk} did not finish successfully.')
+        spec.exit_code(
+            600,
+            'ERROR_NOT_ENOUGH_EVALUATE_WORKFLOW',
+            message='The number of sub evaluation processes {n} is not enough.'
+        )
+        spec.exit_code(
+            510,
+            'ERROR_DIFFERENT_SIZE_OF_ECUTOFF_PAIRS',
+            message='The ecutwfc_list and ecutrho_list have incompatible size.'
+        )
+
+    @abstractmethod
+    def get_create_process(self):
+        """
+        the create process
+        """
+
+    @abstractmethod
+    def get_evaluate_process(self):
+        """
+        the evaluate process
+        """
+
+    @abstractmethod
+    def get_parsed_results(self) -> ty.Dict[str, str]:
+        """
+        Defined the return values will be recorded in output_parameters
+        This method return a dict with keys as name of results and values as
+        the unit of corresponding results.
+        The results are read from the evaluate helper function defined in `get_evaluate_process`.
+        """
+
+    @abstractmethod
+    def get_converge_y(self) -> ty.Tuple[str, ty.Tuple[str, str]]:
+        """
+        The name of value in the output of evaluate process, use in as the
+        convergence value.
+        The first element of tuple is the name of the value and the second is
+        a tuple of (<description>, <unit>).
+        """
+
+    def init_step(self):
+        """
+        A empty initial step which customized by user
+        """
+
+    def final_step(self):
+        """
+        A empty final step which customized by user
+        """
+
+    def setup(self):
+        self.ctx.ecutwfc_list = self.inputs.parameters.ecutwfc_list.get_list()
+        self.ctx.ecutrho_list = self.inputs.parameters.ecutrho_list.get_list()
+        if not len(self.ctx.ecutwfc_list) == len(self.ctx.ecutrho_list):
+            return self.exit_codes.ERROR_DIFFERENT_SIZE_OF_ECUTOFF_PAIRS
+
+    def validate_structure(self):
+        res = get_pw_inputs_from_pseudo(pseudo=self.inputs.pseudo)
+
+        self.ctx.structure = res['structure']
+        self.ctx.pseudos = res['pseudos']
+        self.ctx.base_pw_parameters = res['base_pw_parameters']
+
+    def run_ref(self):
+        """
+        Running the calculation for the reference point
+        hard code to 200Ry at the moment
+        """
+        cutoff_pair = self.inputs.parameters.ref_cutoff_pair.get_list()
+        ecutwfc = cutoff_pair[0]
+        ecutrho = cutoff_pair[1]
+        inputs = self.get_create_process_inputs()
+
+        inputs['parameters']['ecutwfc'] = orm.Float(ecutwfc)
+        inputs['parameters']['ecutrho'] = orm.Float(ecutrho)
+
+        running = self.submit(self.get_create_process(), **inputs)
+
+        self.report(
+            f'launching reference CohesiveEnergyWorkChain<{running.pk}>.')
+
+        return ToContext(ref_workchain=running)
+
+    @abstractmethod
+    def get_create_process_inputs(self) -> ty.Dict[str, ty.Any]:
+        """
+        The inputs used to running the create workflow
+        Normally the corresponding property evaluation workflow.
+        """
+
+    @abstractmethod
+    def get_evaluate_process_inputs(self) -> ty.Dict[str, ty.Any]:
+        """
+        The inputs used to running the evaluate workflow
+        Including inputs not passed from the previous create workflow
+        Normally the reference value of `run_ref` step.
+        """
+
+    @abstractmethod
+    def get_output_input_mapping(self) -> orm.Dict:
+        """
+        return output_input_mapping from create workflow to
+        evaluate workflow
+        """
+
+    def run_all(self):
+        """
+        Running the calculation for other points
+        """
+        ref_workchain = self.ctx.ref_workchain
+
+        if not ref_workchain.is_finished_ok:
+            self.report(
+                f'Reference run of CohesiveEnergyWorkChain failed with exit status {ref_workchain.exit_status}'
+            )
+            return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(
+                pk=ref_workchain.pk)
+
+        create_evaluate_inputs = {
+            'create_process': get_fullname(self.get_create_process()),
+            'evaluate_process': get_fullname(self.get_evaluate_process()),
+            'create': self.get_create_process_inputs(),
+            'evaluate': self.get_evaluate_process_inputs(),
+            'output_input_mapping': self.get_output_input_mapping(),
+        }
+
+        input_values = list(zip(self.ctx.ecutwfc_list, self.ctx.ecutrho_list))
+
+        self.ctx.converge_y_name, self.ctx.converge_y_unit = self.get_converge_y(
+        )
+        inputs = {
+            'engine':
+            TwoInputsTwoFactorsConvergence,
+            'engine_kwargs':
+            orm.Dict(
+                dict={
+                    'input_values': input_values,
+                    'tol': self._TOLERANCE,
+                    'conv_thr': self._CONV_THR_CONV,
+                    'input_key': 'create.parameters.ecutwfc',
+                    'extra_input_key': 'create.parameters.ecutrho',
+                    'result_key':
+                    f'evaluate.result:{self.ctx.converge_y_name}',
+                    'convergence_window': self._CONV_WINDOW
+                }),
+            'evaluate_process':
+            CreateEvaluateWorkChain,
+            'evaluate':
+            create_evaluate_inputs,
+        }
+
+        running = self.submit(OptimizationWorkChain, **inputs)
+        self.report(
+            f'submitting cohesive energy convergence workflow pk={running.pk}.'
+        )
+        return ToContext(convergence_workchain=running)
+
+    def results(self):
+        """
+        doc
+        """
+        workchain = self.ctx.convergence_workchain
+
+        if workchain.is_finished_ok:
+            self.report(f'Convergence workflow pk={workchain.pk} finish ok.')
+            optimal_process_uuid = workchain.outputs.optimal_process_uuid.value
+            optimal_process = orm.load_node(optimal_process_uuid)
+            res = {
+                'converge_ecutwfc':
+                optimal_process.inputs.create__parameters__ecutwfc,
+                'converge_ecutrho':
+                optimal_process.inputs.create__parameters__ecutrho,
+                'converge_value':
+                workchain.outputs.optimal_process_output.value,
+                'converge_process_uuid':
+                workchain.outputs.optimal_process_uuid.value,
+            }
+            self.out('output_convergence_parameters',
+                     orm.Dict(dict=res).store())
+
+        if not workchain.is_finished:
+            self.report(
+                f'Reference run of Convergence optimize workchain pk={workchain.pk} '
+                f'failed with exit status {workchain.exit_status}')
+            return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(
+                pk=workchain.pk)
+
+        if workchain.is_finished and workchain.exit_status == 202:
+            self.report(
+                f'Convergence workflow pk={workchain.pk} is finished but not converge.'
+            )
+
+        import numpy as np
+
+        self.ctx.children = [
+            child for child in workchain.get_outgoing().all_nodes()
+            if isinstance(child, orm.WorkChainNode)
+        ]
+        pks = [child.pk for child in self.ctx.children if child.is_finished_ok]
+        if len(pks) / len(self.ctx.children) < 0.8:
+            self.report(
+                f'Not enough finish ok evaluate workflow, '
+                f'expect 80% only get number of {len(pks)} workflow, '
+                f'that is {len(pks) / len(self.ctx.children)} of total.')
+            return self.exit_codes.ERROR_NOT_ENOUGH_EVALUATE_WORKFLOW.format(
+                n=len(pks))
+
+        success_child = [
+            child for child in self.ctx.children if child.is_finished_ok
+        ]
+        ecutwfc_list = []
+        ecutrho_list = []
+
+        results_parser_dict = self.get_parsed_results()
+        output_parameters_dict = {}
+        for key in results_parser_dict:
+            output_parameters_dict[key] = []
+
+        for child in success_child:
+            ecutwfc = child.inputs.create__parameters__ecutwfc.value
+            ecutrho = child.inputs.create__parameters__ecutrho.value
+
+            ecutwfc_list.append(ecutwfc)
+            ecutrho_list.append(ecutrho)
+
+            # loop over all output properties of evaluate process
+            # set the results in the list of corresponding name.
+            for key in output_parameters_dict:
+                res = child.outputs.evaluate__result[key]
+                output_parameters_dict[key].append(res)
+
+        for key in list(output_parameters_dict):
+            output_parameters_dict[f'{key}_description'] = results_parser_dict[
+                key]
+
+        output_parameters_dict['ecutwfc_list'] = ecutwfc_list
+        output_parameters_dict['ecutrho_list'] = ecutrho_list
+
+        xy_data_ecutwfc = orm.XyData()
+        xy_data_ecutwfc.set_x(np.array(ecutwfc_list), 'wavefunction cutoff',
+                              'Rydberg')
+
+        xy_data_ecutrho = orm.XyData()
+        xy_data_ecutrho.set_x(np.array(ecutrho_list), 'charge density cutoff',
+                              'Rydberg')
+
+        ys_list = []
+        ys_description = []
+        ys_unit = []
+        for y_key, y_value in results_parser_dict.items():
+            ys_list.append(np.array(output_parameters_dict[y_key]))
+            ys_description.append(y_value[0])
+            ys_unit.append(y_value[1])
+        xy_data_ecutwfc.set_y(ys_list, ys_description, ys_unit)
+        self.out('xy_data_ecutwfc', xy_data_ecutwfc.store())
+        xy_data_ecutrho.set_y(ys_list, ys_description, ys_unit)
+        self.out('xy_data_ecutrho', xy_data_ecutrho.store())
+
+        output_parameters = orm.Dict(dict=output_parameters_dict)
+        self.out('output_parameters', output_parameters.store())

--- a/aiida_sssp_workflow/workflows/convergence/cohesive_energy.py
+++ b/aiida_sssp_workflow/workflows/convergence/cohesive_energy.py
@@ -43,20 +43,7 @@ PARA_ECUTRHO_LIST = lambda: orm.List(list=[
 
 class ConvergenceCohesiveEnergyWorkChain(BaseConvergenceWorkChain):
     """WorkChain to converge test on cohisive energy of input structure"""
-
-    # hard code parameters of evaluate workflow
-    _DEGUASS = 0.00735
-    _OCCUPATIONS = 'smearing'
-    _BULK_SMEARING = 'marzari-vanderbilt'
-    _ATOM_SMEARING = 'gaussian'
-    _CONV_THR_EVA = 1e-10
-    _KDISTANCE = 0.15
-    _VACUUM_LENGTH = 12.0
-
-    # hard code parameters of convergence workflow
-    _TOLERANCE = 1e-1
-    _CONV_THR_CONV = 1e-1
-    _CONV_WINDOW = 3
+    # pylint: disable=too-many-instance-attributes
 
     @classmethod
     def define(cls, spec):
@@ -64,6 +51,23 @@ class ConvergenceCohesiveEnergyWorkChain(BaseConvergenceWorkChain):
         spec.input('code',
                    valid_type=orm.Code,
                    help='The `pw.x` code use for the `PwCalculation`.')
+
+    def setup_protocol(self):
+        # pylint: disable=invalid-name, attribute-defined-outside-init
+        protocol_name = self.inputs.protocol.value
+        protocol = self._get_protocol()[protocol_name]
+        protocol = protocol['convergence']['cohesive_energy']
+        self._DEGUASS = protocol['degauss']
+        self._OCCUPATIONS = protocol['occupations']
+        self._BULK_SMEARING = protocol['bulk_smearing']
+        self._ATOM_SMEARING = protocol['atom_smearing']
+        self._CONV_THR_EVA = protocol['electron_conv_thr']
+        self._KDISTANCE = protocol['kpoints_distance']
+        self._VACUUM_LENGTH = protocol['vaccum_length']
+
+        self._TOLERANCE = protocol['tolerance']
+        self._CONV_THR_CONV = protocol['convergence_conv_thr']
+        self._CONV_WINDOW = protocol['convergence_window']
 
     def get_create_process(self):
         return CohesiveEnergyWorkChain
@@ -78,7 +82,7 @@ class ConvergenceCohesiveEnergyWorkChain(BaseConvergenceWorkChain):
         }
 
     def get_converge_y(self):
-        return 'relative_diff', '%'
+        return 'absolute_diff', 'eV/atom'
 
     def get_create_process_inputs(self):
         _PW_BULK_PARAS = {   # pylint: disable=invalid-name

--- a/aiida_sssp_workflow/workflows/convergence/pressure.py
+++ b/aiida_sssp_workflow/workflows/convergence/pressure.py
@@ -71,20 +71,7 @@ def helper_pressure_difference(input_parameters: orm.Dict,
 
 class ConvergencePressureWorkChain(BaseConvergenceWorkChain):
     """WorkChain to converge test on pressure of input structure"""
-
-    # hard code parameters of evaluate workflow
-    _DEGUASS = 0.00735
-    _OCCUPATIONS = 'smearing'
-    _SMEARING = 'marzari-vanderbilt'
-    _KDISTANCE = 0.15
-    _CONV_THR = 1e-10
-
-    # hard code parameters of convergence workflow
-    _TOLERANCE = 1e-1
-    _CONV_THR_CONV = 1e-1
-    _CONV_WINDOW = 3
-
-    _ABSOLUTE_UNIT = 'GPascal'
+    # pylint: disable=too-many-instance-attributes
 
     @classmethod
     def define(cls, spec):
@@ -97,6 +84,21 @@ class ConvergencePressureWorkChain(BaseConvergenceWorkChain):
             valid_type=orm.Dict,
             help=
             'birch murnaghan fit results used in residual volume evaluation.')
+
+    def setup_protocol(self):
+        # pylint: disable=invalid-name, attribute-defined-outside-init
+        protocol_name = self.inputs.protocol.value
+        protocol = self._get_protocol()[protocol_name]
+        protocol = protocol['convergence']['pressure']
+        self._DEGUASS = protocol['degauss']
+        self._OCCUPATIONS = protocol['occupations']
+        self._SMEARING = protocol['smearing']
+        self._CONV_THR_EVA = protocol['electron_conv_thr']
+        self._KDISTANCE = protocol['kpoints_distance']
+
+        self._TOLERANCE = protocol['tolerance']
+        self._CONV_THR_CONV = protocol['convergence_conv_thr']
+        self._CONV_WINDOW = protocol['convergence_window']
 
     def get_create_process(self):
         return PressureWorkChain
@@ -123,7 +125,7 @@ class ConvergencePressureWorkChain(BaseConvergenceWorkChain):
                 'smearing': self._SMEARING,
             },
             'ELECTRONS': {
-                'conv_thr': self._CONV_THR,
+                'conv_thr': self._CONV_THR_EVA,
             },
         }
 

--- a/aiida_sssp_workflow/workflows/phonon_frequencies.py
+++ b/aiida_sssp_workflow/workflows/phonon_frequencies.py
@@ -94,6 +94,20 @@ class PhononFrequenciesWorkChain(WorkChain):
                    valid_type=orm.Dict,
                    default=PH_PARAS,
                    help='parameters for ph.x.')
+        spec.input(
+            'parameters.ecutwfc',
+            valid_type=(orm.Float, orm.Int),
+            required=False,
+            help=
+            'The ecutwfc set for both atom and bulk calculation. Please also set ecutrho if ecutwfc is set.'
+        )
+        spec.input(
+            'parameters.ecutrho',
+            valid_type=(orm.Float, orm.Int),
+            required=False,
+            help=
+            'The ecutrho set for both atom and bulk calculation.  Please also set ecutwfc if ecutrho is set.'
+        )
         spec.input('parameters.qpoints',
                    valid_type=orm.List,
                    default=lambda: orm.List(list=[[0., 0., 0.]]),
@@ -125,11 +139,21 @@ class PhononFrequenciesWorkChain(WorkChain):
 
     def setup(self):
         """Input validation"""
-        # TODO set ecutwfc and ecutrho according to certain protocol
         pw_parameters = self._PW_PARAMETERS
         pw_parameters = update_dict(pw_parameters,
                                     self.inputs.parameters.pw.get_dict())
+
+        if self.inputs.parameters.ecutwfc and self.inputs.parameters.ecutrho:
+            parameters = {
+                'SYSTEM': {
+                    'ecutwfc': self.inputs.parameters.ecutwfc,
+                    'ecutrho': self.inputs.parameters.ecutrho,
+                },
+            }
+            pw_parameters = update_dict(pw_parameters, parameters)
+
         self.ctx.pw_parameters = pw_parameters
+
         self.ctx.kpoints_distance = self.inputs.parameters.kpoints_distance
 
         # ph.x

--- a/aiida_sssp_workflow/workflows/protocol.yml
+++ b/aiida_sssp_workflow/workflows/protocol.yml
@@ -1,0 +1,139 @@
+efficiency:
+    name: 'efficiency'
+    description: 'Protocol to verify a pseudopotential.'
+
+    delta_factor:
+        occupations: smearing
+        degauss: 0.00735
+        smearing: 'marzari-vanderbilt'
+        electron_conv_thr: 1.0e-10
+        kpoints_distance: 0.1
+        ecutwfc: 200.0
+        wall_time_seconds: 3600
+        scale_count: 7
+        scale_increment: 0.02
+
+    convergence:
+
+        cohesive_energy:
+            occupations: smearing
+            degauss: 0.00735
+            bulk_smearing: 'marzari-vanderbilt'
+            atom_smearing: 'gaussian'
+            electron_conv_thr: 1.0e-10
+            kpoints_distance: 0.15
+            vaccum_length: 12.0
+
+            tolerance: 0.0001 # (eV/atom)
+            convergence_conv_thr: 0.002 # (eV/atom)
+            convergence_window: 3
+
+        phonon_frequencies:
+            occupations: smearing
+            degauss: 0.00735
+            smearing: 'marzari-vanderbilt'
+            electron_conv_thr: 1.0e-10
+            kpoints_distance: 0.15
+            qpoints_list:
+                - [0.5, 0.5, 0.5]
+            ph:
+                epsilon: false
+                tr2_ph: 1.0e-16
+
+            tolerance: 0.1 # 0.1(%)
+            convergence_conv_thr: 2.0 # 2.0(%)
+            convergence_window: 3
+
+        pressure:
+            occupations: smearing
+            degauss: 0.00735
+            smearing: 'marzari-vanderbilt'
+            electron_conv_thr: 1.0e-10
+            kpoints_distance: 0.15
+
+            tolerance: 0.1 # 0.1(%)
+            convergence_conv_thr: 1.0 # 1.0(%)
+            convergence_window: 3
+
+        bands_distance:
+            occupations: smearing
+            degauss: 0.00735
+            smearing: 'marzari-vanderbilt'
+            electron_conv_thr: 1.0e-10
+            scf_kpoints_distance: 0.15
+            band_kpoints_distance: 0.20
+            init_nbnd_factor: 2.0
+
+            tolerance: 0.001 # eV
+            convergence_conv_thr: 0.01 # eV
+            convergence_window: 3
+
+precision:
+    name: 'precision'
+    description: 'Protocol to verify a pseudopotential.'
+
+    delta_factor:
+        occupations: smearing
+        degauss: 0.00735
+        smearing: 'marzari-vanderbilt'
+        electron_conv_thr: 1.0e-10
+        kpoints_distance: 0.1
+        ecutwfc: 200.0
+        wall_time_seconds: 3600
+        scale_count: 7
+        scale_increment: 0.02
+
+    convergence:
+
+        cohesive_energy:
+            occupations: smearing
+            degauss: 0.00735
+            bulk_smearing: 'marzari-vanderbilt'
+            atom_smearing: 'gaussian'
+            electron_conv_thr: 1.0e-10
+            kpoints_distance: 0.15
+            vaccum_length: 12.0
+
+            tolerance: 0.0001 # (eV/atom)
+            convergence_conv_thr: 0.002 # (eV/atom)
+            convergence_window: 3
+
+        phonon_frequencies:
+            occupations: smearing
+            degauss: 0.00735
+            smearing: 'marzari-vanderbilt'
+            electron_conv_thr: 1.0e-10
+            kpoints_distance: 0.15
+            qpoints_list:
+                - [0.5, 0.5, 0.5]
+            ph:
+                epsilon: false
+                tr2_ph: 1.0e-16
+
+            tolerance: 0.1 # 0.1(%)
+            convergence_conv_thr: 1.0 # 2.0(%)
+            convergence_window: 3
+
+        pressure:
+            occupations: smearing
+            degauss: 0.00735
+            smearing: 'marzari-vanderbilt'
+            electron_conv_thr: 1.0e-10
+            kpoints_distance: 0.15
+
+            tolerance: 0.1 # 0.1(%)
+            convergence_conv_thr: 0.5 # 1.0(%)
+            convergence_window: 3
+
+        bands_distance:
+            occupations: smearing
+            degauss: 0.00735
+            smearing: 'marzari-vanderbilt'
+            electron_conv_thr: 1.0e-10
+            scf_kpoints_distance: 0.15
+            band_kpoints_distance: 0.20
+            init_nbnd_factor: 2.0
+
+            tolerance: 0.001 # eV
+            convergence_conv_thr: 0.01 # eV
+            convergence_window: 3

--- a/examples/example_band.py
+++ b/examples/example_band.py
@@ -10,7 +10,7 @@ ConvergenceBandsWorkChain = WorkflowFactory('sssp_workflow.convergence.bands')
 
 
 def run_test(code, upf, dual):
-    ecutwfc = np.array([30, 35, 200])
+    ecutwfc = np.array([30, 35, 40, 45, 50, 55, 60, 200])
     ecutrho = ecutwfc * dual
     PARA_ECUTWFC_LIST = orm.List(list=list(ecutwfc))
     PARA_ECUTRHO_LIST = orm.List(list=list(ecutrho))

--- a/examples/example_cohesive_energy.py
+++ b/examples/example_cohesive_energy.py
@@ -12,7 +12,7 @@ ConvergenceCohesiveEnergy = WorkflowFactory(
 
 
 def run_test(code, upf, dual):
-    ecutwfc = np.array([30, 35, 200])
+    ecutwfc = np.array([30, 35, 40, 45, 50, 55, 60, 200])
     ecutrho = ecutwfc * dual
     PARA_ECUTWFC_LIST = orm.List(list=list(ecutwfc))
     PARA_ECUTRHO_LIST = orm.List(list=list(ecutrho))

--- a/examples/example_delta_factor.py
+++ b/examples/example_delta_factor.py
@@ -27,9 +27,6 @@ def run_delta(code, upf, is_nc=False):
                 'max_wallclock_seconds': 1800 * 3,
                 'withmpi': True,
             }),
-        'parameters': {
-            'ecutwfc': orm.Float(ecutwfc),
-        },
     })
 
     node = submit(DeltaFactorWorkChain, **inputs)

--- a/examples/example_phonon.py
+++ b/examples/example_phonon.py
@@ -11,14 +11,12 @@ ConvergencePhononFrequencies = WorkflowFactory(
 
 
 def run_test(pw_code, ph_code, upf, dual):
-    ecutwfc = np.array([30, 35, 200])
-    # ecutwfc = np.array(
-    #     [30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 90, 100, 120, 150, 200])
+    ecutwfc = np.array([30, 35, 40, 45, 50, 55, 60, 200])
     ecutrho = ecutwfc * dual
     PARA_ECUTWFC_LIST = orm.List(list=list(ecutwfc))
     PARA_ECUTRHO_LIST = orm.List(list=list(ecutrho))
 
-    inputs = AttributeDict({
+    inputs = {
         'pw_code': pw_code,
         'ph_code': ph_code,
         'pseudo': upf,
@@ -27,7 +25,7 @@ def run_test(pw_code, ph_code, upf, dual):
             'ecutrho_list': PARA_ECUTRHO_LIST,
             'ref_cutoff_pair': orm.List(list=[200, 200 * dual])
         },
-    })
+    }
     node = submit(ConvergencePhononFrequencies, **inputs)
 
     return node

--- a/examples/example_pressure.py
+++ b/examples/example_pressure.py
@@ -5,7 +5,7 @@ from aiida import orm
 from aiida.common import AttributeDict
 from aiida.plugins import WorkflowFactory
 
-from aiida_sssp_workflow.workflows.convergence.pressure import helper_get_v0_b0_b1
+from aiida_sssp_workflow.workflows.helper import helper_get_v0_b0_b1
 
 from aiida.engine import run_get_node, submit
 
@@ -14,7 +14,7 @@ ConvergencePressureWorkChain = WorkflowFactory(
 
 
 def run_test(code, upf, dual):
-    ecutwfc = np.array([30, 35, 200])
+    ecutwfc = np.array([30, 35, 40, 45, 50, 55, 60, 200])
     ecutrho = ecutwfc * dual
     PARA_ECUTWFC_LIST = orm.List(list=list(ecutwfc))
     PARA_ECUTRHO_LIST = orm.List(list=list(ecutrho))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools>=40.8.0', 'wheel', 'reentry~=1.3', 'fastentrypoints~=0.12', 'numpy~=1.17']
+requires = ['setuptools>=40.8.0', 'wheel', 'reentry~=1.3', 'fastentrypoints~=0.12', 'numpy']
 build-backend = 'setuptools.build_meta:__legacy__'
 
 [tool.pylint.format]

--- a/setup.json
+++ b/setup.json
@@ -15,9 +15,10 @@
         "Environment :: Plugins",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering :: Physics"
     ],
-    "version": "0.1.0a0",
+    "version": "0.1.0a1",
     "entry_points": {
         "aiida.data": [
             "sssp_workflow = aiida_sssp_workflow.data:DiffParameters"
@@ -59,7 +60,7 @@
         "aiida-quantumespresso~=3.2",
         "aiida-codtools~=2.1",
         "aiida-optimize~=0.4",
-        "numpy~=1.17",
+        "numpy",
         "ase~=3.20",
         "seekpath~=1.9",
         "importlib-resources~=3.3",

--- a/setup.json
+++ b/setup.json
@@ -1,16 +1,21 @@
 {
     "name": "aiida-sssp-workflow",
-    "author": "The AiiDA Team",
+    "author": "Jason Yu",
     "author_email": "morty.yeu@gmail.com",
-    "description": "SSSP verification workflows",
+    "description": "AiiDA plugin SSSP verification workflows",
     "url": "https://github.com/aiidateam/aiida-sssp-workflow",
+    "python_requires": ">=3.7",
     "license": "MIT",
     "classifiers": [
         "Programming Language :: Python",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
-        "Framework :: AiiDA"
+        "Framework :: AiiDA",
+        "Environment :: Plugins",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Topic :: Scientific/Engineering :: Physics"
     ],
     "version": "0.1.0a0",
     "entry_points": {

--- a/tests/sample_processes.py
+++ b/tests/sample_processes.py
@@ -1,7 +1,7 @@
 """helper workfunction"""
-from aiida.engine import workfunction
+from aiida.engine import calcfunction
 
 
-@workfunction
-def echo_workfunction(x):
-    return x
+@calcfunction
+def echo_calcfunction(x, y):
+    return x + y

--- a/tests/test_calcfunction.py
+++ b/tests/test_calcfunction.py
@@ -90,7 +90,7 @@ def test_get_v0_b0_b1():
     """
     doc
     """
-    from aiida_sssp_workflow.workflows.convergence.pressure import helper_get_v0_b0_b1
+    from aiida_sssp_workflow.workflows.helper import helper_get_v0_b0_b1
 
     res = helper_get_v0_b0_b1(orm.Str('Si'))
     assert res['V0'].value == 20.4530
@@ -114,25 +114,26 @@ def test_get_volume_from_pressure_birch_murnaghan():
     """
     from aiida_sssp_workflow.workflows.convergence.pressure import helper_get_volume_from_pressure_birch_murnaghan
 
-    V0 = orm.Float(20.4530)
-    B0 = orm.Float(88.545)
-    B1 = orm.Float(4.31)
-    P = orm.Float(0.01)
+    V0 = 20.4530
+    B0 = 88.545
+    B1 = 4.31
+    P = 0.01
 
     ret = helper_get_volume_from_pressure_birch_murnaghan(P, V0, B0, B1)
 
     # check that very small residual pressure correspond a small volume change
-    assert ret.value - 20.4530 < 0.1
+    assert ret - 20.4530 < 0.1
 
 
 def test_phonon_frequencies_diff():
     """test of helper_get_relative_phonon_frequencies"""
-    from aiida_sssp_workflow.workflows.convergence.phonon_frequencies import helper_get_relative_phonon_frequencies
+    from aiida_sssp_workflow.workflows.convergence.phonon_frequencies import helper_phonon_frequencies_difference
 
-    freq = orm.List(list=[1., 1., 1.])
-    ref_freq = orm.List(list=[1., 1., 1.])
+    input_parameters = {'dynamical_matrix_0': {'frequencies': [1., 1., 1.]}}
+    ref_parameters = {'dynamical_matrix_0': {'frequencies': [1., 1., 1.]}}
 
-    res = helper_get_relative_phonon_frequencies(freq, ref_freq)
+    res = helper_phonon_frequencies_difference(orm.Dict(dict=input_parameters),
+                                               orm.Dict(dict=ref_parameters))
 
     assert res['relative_diff'] == 0.0
     assert res['relative_max_diff'] == 0.0

--- a/tests/test_convergence_engine.py
+++ b/tests/test_convergence_engine.py
@@ -1,12 +1,15 @@
 from aiida import orm
 from aiida.plugins import WorkflowFactory
 
-from .sample_processes import echo_workfunction
-from aiida_sssp_workflow.workflows.convergence.engine import TwoFactorConvergence
+from .sample_processes import echo_calcfunction
+from aiida_sssp_workflow.workflows.convergence.engine import TwoInputsTwoFactorsConvergence
 
 from aiida.engine import run
 
 OptimizationWorkChain = WorkflowFactory('optimize.optimize')
+
+_INPUT_VALUES = [(1, 2), (1, 1), (1.0, 0.3), (1.0, 0.2), (0.002, 0.100),
+                 (0.0793, 0.02), (0.0794, 0.02), (0.0792, 0.02)]
 
 
 def test_condition_1():
@@ -17,20 +20,20 @@ def test_condition_1():
     """
     inputs = {
         'engine':
-        TwoFactorConvergence,
+        TwoInputsTwoFactorsConvergence,
         'engine_kwargs':
         orm.Dict(
             dict={
-                'input_values':
-                [3, 2, 1.3, 1.2, 0.102, 0.0993, 0.0994, 0.0992],
+                'input_values': _INPUT_VALUES,
                 'tol': 1e-2,
                 'conv_thr': 2,
                 'input_key': 'x',
+                'extra_input_key': 'y',
                 'result_key': 'result',
                 'convergence_window': 2
             }),
         'evaluate_process':
-        echo_workfunction,
+        echo_calcfunction
     }
 
     res = run(OptimizationWorkChain, **inputs)
@@ -45,20 +48,20 @@ def test_condition_2():
     """
     inputs = {
         'engine':
-        TwoFactorConvergence,
+        TwoInputsTwoFactorsConvergence,
         'engine_kwargs':
         orm.Dict(
             dict={
-                'input_values':
-                [3, 2, 1.3, 1.2, 0.102, 0.0993, 0.0994, 0.0992],
+                'input_values': _INPUT_VALUES,
                 'tol': 1e-2,
                 'conv_thr': 1e-1,
                 'input_key': 'x',
+                'extra_input_key': 'y',
                 'result_key': 'result',
                 'convergence_window': 2
             }),
         'evaluate_process':
-        echo_workfunction,
+        echo_calcfunction
     }
 
     res = run(OptimizationWorkChain, **inputs)


### PR DESCRIPTION
fix #23 

The convergence workflows of cohesive energy, phonon frequencies,
pressure, banis distance have the same working logic. Therefore, a
`BaseConvergenceWorkChain` is create as a meta class to include the
common steps of all the convergence workflows. The following methods
need to be explicitly defined to create a new workflow of specific
evaluation properties, other methods can be ovrwrite if necessary:

* `get_create_process`: for the create process of
  `CreateEvaluateWorkChain` which run the properties calculation.
* `get_evaluate_process`: for the evaluate process of
  `CreateEvaluatWorkChain` which do the further output analysis of the
  previous create process.
* `get_parsed_results`: a dict to define the results to be recorded in
  the `output_parameters` of workflow.
* `get_converge_y`: a tuple, whose first element is the evaluate result
  used to determine if the test is converged.
* `get_create_process_inputs`: return the inputs for the create process.
* `get_evaluate_process_inputs`: return the inputs for the evaluate
  proces, these are inputs not change with the converge step.
* `get_output_input_mapping`: mapping the outputs name of create process
  to the name of evaluate inputs.