### PR TITLE
Simplify the pw inputs generator of convergence WF

### DIFF
--- a/aiida_sssp_workflow/workflows/bands.py
+++ b/aiida_sssp_workflow/workflows/bands.py
@@ -135,6 +135,8 @@ class BandsWorkChain(WorkChain):
                                         self.inputs.parameters.pw.get_dict())
         pw_bands_parameters = update_dict(bands_parameters,
                                           self.inputs.parameters.pw.get_dict())
+        pw_bands_parameters['SYSTEM'].pop(
+            'nbnd', None)  # Since nbnd can not sit with nband_factor
         self.ctx.pw_scf_parameters = orm.Dict(dict=pw_scf_parameters)
         self.ctx.pw_bands_parameters = orm.Dict(dict=pw_bands_parameters)
 

--- a/aiida_sssp_workflow/workflows/convergence/bands.py
+++ b/aiida_sssp_workflow/workflows/convergence/bands.py
@@ -2,17 +2,13 @@
 """
 Convergence test on bands of a given pseudopotential
 """
-import importlib_resources
 from aiida.common import AttributeDict
 from aiida.engine import WorkChain, ToContext, append_
 from aiida import orm
 from aiida.plugins import WorkflowFactory
 
-from aiida.common.files import md5_file
-from aiida_sssp_workflow.workflows.delta_factor import helper_parse_upf, \
-    get_standard_cif_filename_from_element, \
-    helper_create_standard_cif_from_element, \
-    RARE_EARTH_ELEMENTS, update_dict
+from aiida_sssp_workflow.utils import update_dict
+from ..helper import get_pw_inputs_from_pseudo
 
 BandsWorkChain = WorkflowFactory('sssp_workflow.bands')
 
@@ -97,58 +93,11 @@ class ConvergenceBandsWorkChain(WorkChain):
             return self.exit_codes.ERROR_DIFFERENT_SIZE_OF_ECUTOFF_PAIRS
 
     def validate_structure(self):
-        upf_info = helper_parse_upf(self.inputs.pseudo)
-        element = orm.Str(upf_info['element'])
+        res = get_pw_inputs_from_pseudo(pseudo=self.inputs.pseudo)
 
-        pseudos = {element.value: self.inputs.pseudo}
-        self.ctx.element = element
-
-        if element.value == 'F':
-            self.ctx.element = orm.Str('SiF4')
-
-            fpath = importlib_resources.path('aiida_sssp_workflow.REF.UPFs',
-                                             'Si.pbe-n-rrkjus_psl.1.0.0.UPF')
-            with fpath as path:
-                filename = str(path)
-                upf_silicon = orm.UpfData.get_or_create(filename)[0]
-                pseudos['Si'] = upf_silicon
-
-        pw_parameters = {}
-        if element.value in RARE_EARTH_ELEMENTS:
-            fpath = importlib_resources.path('aiida_sssp_workflow.REF.UPFs',
-                                             'N.pbe-n-radius_5.UPF')
-            with fpath as path:
-                filename = str(path)
-                upf_nitrogen = orm.UpfData.get_or_create(filename)[0]
-                pseudos['N'] = upf_nitrogen
-
-            # z_valence_RE = upf_info['z_valence']  # pylint: disable=invalid-name
-            # z_valence_N = helper_parse_upf(upf_nitrogen)['z_valence']  # pylint: disable=invalid-name
-            # nbands = (z_valence_N + z_valence_RE) // 2
-            # nbands_factor = 2
-            pw_parameters = {
-                'SYSTEM': {
-                    # nbnd should not appear with nbnd_factor setting in sub-workflow
-                    # 'nbnd': int(nbands * nbands_factor),
-                },
-            }
-
-        filename = get_standard_cif_filename_from_element(
-            self.ctx.element.value)
-
-        md5 = md5_file(filename)
-        cifs = orm.CifData.from_md5(md5)
-        if not cifs:
-            # cif not stored, create it with calcfunction and return it
-            cif_data = helper_create_standard_cif_from_element(
-                self.ctx.element)
-        else:
-            # The Cif is already store let's return it
-            cif_data = orm.CifData.get_or_create(filename)[0]
-
-        self.ctx.structure = cif_data.get_structure(primitive_cell=True)
-        self.ctx.pseudos = pseudos
-        self.ctx.pw_parameters = pw_parameters
+        self.ctx.structure = res['structure']
+        self.ctx.pseudos = res['pseudos']
+        self.ctx.base_pw_parameters = res['base_pw_parameters']
 
     def get_inputs(self,
                    ecutwfc,
@@ -173,10 +122,14 @@ class ConvergenceBandsWorkChain(WorkChain):
             'structure': self.ctx.structure,
             'parameters': {
                 'pw':
-                orm.Dict(dict=update_dict(_PW_PARAS, self.ctx.pw_parameters)),
-                'scf_kpoints_distance': orm.Float(self._SCF_KDISTANCE),
-                'bands_kpoints_distance': orm.Float(self._BAND_KDISTANCE),
-                'nbands_factor': nbands_factor,
+                orm.Dict(
+                    dict=update_dict(_PW_PARAS, self.ctx.base_pw_parameters)),
+                'scf_kpoints_distance':
+                orm.Float(self._SCF_KDISTANCE),
+                'bands_kpoints_distance':
+                orm.Float(self._BAND_KDISTANCE),
+                'nbands_factor':
+                nbands_factor,
             },
         })
 

--- a/aiida_sssp_workflow/workflows/convergence/phonon_frequencies.py
+++ b/aiida_sssp_workflow/workflows/convergence/phonon_frequencies.py
@@ -2,17 +2,13 @@
 """
 Convergence test on cohesive energy of a given pseudopotential
 """
-import importlib_resources
 from aiida.common import AttributeDict
 from aiida.engine import WorkChain, ToContext, append_, calcfunction
 from aiida import orm
 from aiida.plugins import WorkflowFactory
 
-from aiida.common.files import md5_file
-from aiida_sssp_workflow.workflows.delta_factor import helper_parse_upf, \
-    get_standard_cif_filename_from_element, \
-    helper_create_standard_cif_from_element, \
-    RARE_EARTH_ELEMENTS, update_dict
+from aiida_sssp_workflow.utils import update_dict
+from ..helper import get_pw_inputs_from_pseudo
 
 PhononFrequenciesWorkChain = WorkflowFactory(
     'sssp_workflow.phonon_frequencies')
@@ -132,57 +128,11 @@ class ConvergencePhononFrequenciesWorkChain(WorkChain):
             return self.exit_codes.ERROR_DIFFERENT_SIZE_OF_ECUTOFF_PAIRS
 
     def validate_structure(self):
-        upf_info = helper_parse_upf(self.inputs.pseudo)
-        element = orm.Str(upf_info['element'])
+        res = get_pw_inputs_from_pseudo(pseudo=self.inputs.pseudo)
 
-        pseudos = {element.value: self.inputs.pseudo}
-        self.ctx.element = element
-
-        if element.value == 'F':
-            self.ctx.element = orm.Str('SiF4')
-
-            fpath = importlib_resources.path('aiida_sssp_workflow.REF.UPFs',
-                                             'Si.pbe-n-rrkjus_psl.1.0.0.UPF')
-            with fpath as path:
-                filename = str(path)
-                upf_silicon = orm.UpfData.get_or_create(filename)[0]
-                pseudos['Si'] = upf_silicon
-
-        pw_parameters = {}
-        if element.value in RARE_EARTH_ELEMENTS:
-            fpath = importlib_resources.path('aiida_sssp_workflow.REF.UPFs',
-                                             'N.pbe-n-radius_5.UPF')
-            with fpath as path:
-                filename = str(path)
-                upf_nitrogen = orm.UpfData.get_or_create(filename)[0]
-                pseudos['N'] = upf_nitrogen
-
-            z_valence_RE = upf_info['z_valence']  # pylint: disable=invalid-name
-            z_valence_N = helper_parse_upf(upf_nitrogen)['z_valence']  # pylint: disable=invalid-name
-            nbands = (z_valence_N + z_valence_RE) // 2
-            nbands_factor = 2
-            pw_parameters = {
-                'SYSTEM': {
-                    'nbnd': int(nbands * nbands_factor),
-                },
-            }
-
-        filename = get_standard_cif_filename_from_element(
-            self.ctx.element.value)
-
-        md5 = md5_file(filename)
-        cifs = orm.CifData.from_md5(md5)
-        if not cifs:
-            # cif not stored, create it with calcfunction and return it
-            cif_data = helper_create_standard_cif_from_element(
-                self.ctx.element)
-        else:
-            # The Cif is already store let's return it
-            cif_data = orm.CifData.get_or_create(filename)[0]
-
-        self.ctx.structure = cif_data.get_structure(primitive_cell=True)
-        self.ctx.pseudos = pseudos
-        self.ctx.pw_parameters = pw_parameters
+        self.ctx.structure = res['structure']
+        self.ctx.pseudos = res['pseudos']
+        self.ctx.base_pw_parameters = res['base_pw_parameters']
 
     def get_inputs(self, ecutwfc, ecutrho):
         _PW_PARAS = {   # pylint: disable=invalid-name
@@ -206,10 +156,14 @@ class ConvergencePhononFrequenciesWorkChain(WorkChain):
             'structure': self.ctx.structure,
             'parameters': {
                 'pw':
-                orm.Dict(dict=update_dict(_PW_PARAS, self.ctx.pw_parameters)),
-                'ph': orm.Dict(dict=_PH_PARAS),
-                'kpoints_distance': orm.Float(self._KDISTANCE),
-                'qpoints': orm.List(list=self._QPOINTS_LIST),
+                orm.Dict(
+                    dict=update_dict(_PW_PARAS, self.ctx.base_pw_parameters)),
+                'ph':
+                orm.Dict(dict=_PH_PARAS),
+                'kpoints_distance':
+                orm.Float(self._KDISTANCE),
+                'qpoints':
+                orm.List(list=self._QPOINTS_LIST),
             },
         })
 

--- a/aiida_sssp_workflow/workflows/convergence/pressure.py
+++ b/aiida_sssp_workflow/workflows/convergence/pressure.py
@@ -2,17 +2,13 @@
 """
 Convergence test on cohesive energy of a given pseudopotential
 """
-import importlib_resources
 from aiida.common import AttributeDict
 from aiida.engine import WorkChain, ToContext, append_, calcfunction
 from aiida import orm
 from aiida.plugins import WorkflowFactory
 
-from aiida.common.files import md5_file
-from aiida_sssp_workflow.workflows.delta_factor import helper_parse_upf, \
-    get_standard_cif_filename_from_element, \
-    helper_create_standard_cif_from_element, \
-    RARE_EARTH_ELEMENTS, update_dict
+from aiida_sssp_workflow.utils import update_dict
+from ..helper import get_pw_inputs_from_pseudo
 
 PressureWorkChain = WorkflowFactory('sssp_workflow.pressure_evaluation')
 
@@ -176,57 +172,11 @@ class ConvergencePressureWorkChain(WorkChain):
             return self.exit_codes.ERROR_DIFFERENT_SIZE_OF_ECUTOFF_PAIRS
 
     def validate_structure(self):
-        upf_info = helper_parse_upf(self.inputs.pseudo)
-        element = orm.Str(upf_info['element'])
+        res = get_pw_inputs_from_pseudo(pseudo=self.inputs.pseudo)
 
-        pseudos = {element.value: self.inputs.pseudo}
-        self.ctx.element = element
-
-        if element.value == 'F':
-            self.ctx.element = orm.Str('SiF4')
-
-            fpath = importlib_resources.path('aiida_sssp_workflow.REF.UPFs',
-                                             'Si.pbe-n-rrkjus_psl.1.0.0.UPF')
-            with fpath as path:
-                filename = str(path)
-                upf_silicon = orm.UpfData.get_or_create(filename)[0]
-                pseudos['Si'] = upf_silicon
-
-        pw_parameters = {}
-        if element.value in RARE_EARTH_ELEMENTS:
-            fpath = importlib_resources.path('aiida_sssp_workflow.REF.UPFs',
-                                             'N.pbe-n-radius_5.UPF')
-            with fpath as path:
-                filename = str(path)
-                upf_nitrogen = orm.UpfData.get_or_create(filename)[0]
-                pseudos['N'] = upf_nitrogen
-
-            z_valence_RE = upf_info['z_valence']  # pylint: disable=invalid-name
-            z_valence_N = helper_parse_upf(upf_nitrogen)['z_valence']  # pylint: disable=invalid-name
-            nbands = (z_valence_N + z_valence_RE) // 2
-            nbands_factor = 2
-            pw_parameters = {
-                'SYSTEM': {
-                    'nbnd': int(nbands * nbands_factor),
-                },
-            }
-
-        filename = get_standard_cif_filename_from_element(
-            self.ctx.element.value)
-
-        md5 = md5_file(filename)
-        cifs = orm.CifData.from_md5(md5)
-        if not cifs:
-            # cif not stored, create it with calcfunction and return it
-            cif_data = helper_create_standard_cif_from_element(
-                self.ctx.element)
-        else:
-            # The Cif is already store let's return it
-            cif_data = orm.CifData.get_or_create(filename)[0]
-
-        self.ctx.structure = cif_data.get_structure(primitive_cell=True)
-        self.ctx.pseudos = pseudos
-        self.ctx.pw_parameters = pw_parameters
+        self.ctx.structure = res['structure']
+        self.ctx.pseudos = res['pseudos']
+        self.ctx.base_pw_parameters = res['base_pw_parameters']
 
     def get_inputs(self, ecutwfc, ecutrho):
         _PW_PARAS = {   # pylint: disable=invalid-name
@@ -248,8 +198,10 @@ class ConvergencePressureWorkChain(WorkChain):
             'structure': self.ctx.structure,
             'parameters': {
                 'pw':
-                orm.Dict(dict=update_dict(_PW_PARAS, self.ctx.pw_parameters)),
-                'kpoints_distance': orm.Float(self._KDISTANCE),
+                orm.Dict(
+                    dict=update_dict(_PW_PARAS, self.ctx.base_pw_parameters)),
+                'kpoints_distance':
+                orm.Float(self._KDISTANCE),
             },
         })
 

--- a/aiida_sssp_workflow/workflows/helper.py
+++ b/aiida_sssp_workflow/workflows/helper.py
@@ -1,0 +1,60 @@
+"""
+Module comtain helper functions for workflows
+"""
+import importlib_resources
+
+from aiida import orm
+
+from aiida_sssp_workflow.utils import helper_parse_upf, \
+    RARE_EARTH_ELEMENTS, \
+    get_standard_cif_filename_from_element
+
+
+def get_pw_inputs_from_pseudo(pseudo, primitive_cell=True):
+    """
+    helper method used to generate base pw inputs(structure, pseudos, pw_parameters)
+    lanthanides elements are supported with Rare-Nithides.
+    """
+    upf_info = helper_parse_upf(pseudo)
+    element = orm.Str(upf_info['element'])
+
+    pseudos = {element.value: pseudo}
+
+    if element.value == 'F':
+        element = orm.Str('SiF4')
+
+        fpath = importlib_resources.path('aiida_sssp_workflow.REF.UPFs',
+                                         'Si.pbe-n-rrkjus_psl.1.0.0.UPF')
+        with fpath as path:
+            filename = str(path)
+            upf_silicon = orm.UpfData.get_or_create(filename)[0]
+            pseudos['Si'] = upf_silicon
+
+    pw_parameters = {}
+    if element.value in RARE_EARTH_ELEMENTS:
+        fpath = importlib_resources.path('aiida_sssp_workflow.REF.UPFs',
+                                         'N.pbe-n-radius_5.UPF')
+        with fpath as path:
+            filename = str(path)
+            upf_nitrogen = orm.UpfData.get_or_create(filename)[0]
+            pseudos['N'] = upf_nitrogen
+
+        z_valence_RE = upf_info['z_valence']  # pylint: disable=invalid-name
+        z_valence_N = helper_parse_upf(upf_nitrogen)['z_valence']  # pylint: disable=invalid-name
+        nbands = (z_valence_N + z_valence_RE) // 2
+        nbands_factor = 2
+        pw_parameters = {
+            'SYSTEM': {
+                'nbnd': int(nbands * nbands_factor),
+            },
+        }
+
+    filename = get_standard_cif_filename_from_element(element.value)
+
+    cif_data = orm.CifData.get_or_create(filename)[0]
+
+    return {
+        'structure': cif_data.get_structure(primitive_cell=primitive_cell),
+        'pseudos': pseudos,
+        'base_pw_parameters': pw_parameters,
+    }

--- a/examples/example_band.py
+++ b/examples/example_band.py
@@ -36,9 +36,9 @@ if __name__ == '__main__':
 
     upf_sg15 = {}
     # # sg15/Au_ONCV_PBE-1.2.upf
-    upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
+    # upf_sg15['au'] = load_node('2c467668-2f38-4a8c-8b57-69d67a3fb2a4')
     # sg15/Si_ONCV_PBE-1.2.upf
-    upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
+    upf_sg15['si'] = load_node('39e55083-3fc7-4405-8b3b-54a2c940dc67')
 
     for element, upf in upf_sg15.items():
         dual = 4.0

--- a/examples/example_cohesive_energy.py
+++ b/examples/example_cohesive_energy.py
@@ -38,9 +38,9 @@ if __name__ == '__main__':
 
     upf_sg15 = {}
     # # sg15/Au_ONCV_PBE-1.2.upf
-    upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
+    # upf_sg15['au'] = load_node('2c467668-2f38-4a8c-8b57-69d67a3fb2a4')
     # sg15/Si_ONCV_PBE-1.2.upf
-    upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
+    upf_sg15['si'] = load_node('39e55083-3fc7-4405-8b3b-54a2c940dc67')
 
     for element, upf in upf_sg15.items():
         dual = 4.0

--- a/examples/example_delta_factor.py
+++ b/examples/example_delta_factor.py
@@ -18,7 +18,7 @@ def run_delta(code, upf, is_nc=False):
     else:
         dual = 8
 
-    ecutwfc = 200
+    ecutwfc = 200.0
     ecutrho = ecutwfc * dual
     inputs = AttributeDict({
         'code':
@@ -54,28 +54,11 @@ if __name__ == '__main__':
 
     code = load_code('qe-6.6-pw@daint-mc')
 
-    # upf_gbrv = {}
-    # # GBRV_pbe/au_pbe_v1.uspp.F.UPF
-    # upf_gbrv['au'] = load_node('51f62644-fb95-4b04-9c31-ee732b6d8155')
-    # # GBRV_pbe/o_pbe_v1.2.uspp.F.UPF
-    # upf_gbrv['o'] = load_node('005f1eaa-6746-41f2-8b12-38f6dabe4f61')
-    # # GBRV_pbe/si_pbe_v1.uspp.F.UPF
-    # upf_gbrv['si'] = load_node('15f938a1-9466-4a41-9022-4c6f06cf4e20')
-    #
-    # for element, upf in upf_gbrv.items():
-    #     node = run_delta(code, upf, is_nc=False)
-    #     node.description = f'GBRV_pbe/{element}'
-    #     print(node)
-
     upf_sg15 = {}
-    # sg15/Au_ONCV_PBE-1.2.upf
-    upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
-    # # sg15/O_ONCV_PBE-1.2.upf
-    # upf_sg15['o'] = load_node('52e4e647-d6ef-43c6-b8a1-adfb54bff07e')
+    # # sg15/Au_ONCV_PBE-1.2.upf
+    # upf_sg15['au'] = load_node('2c467668-2f38-4a8c-8b57-69d67a3fb2a4')
     # sg15/Si_ONCV_PBE-1.2.upf
-    upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
-    # # sg15/Xe_ONCV_PBE-1.2.upf
-    # upf_sg15['xe'] = load_node('3a3c2612-9cdc-4fc9-bd37-589fa87fab06')
+    upf_sg15['si'] = load_node('39e55083-3fc7-4405-8b3b-54a2c940dc67')
 
     for element, upf in upf_sg15.items():
         node = run_delta(code, upf, is_nc=True)

--- a/examples/example_phonon.py
+++ b/examples/example_phonon.py
@@ -41,9 +41,9 @@ if __name__ == '__main__':
 
     upf_sg15 = {}
     # # sg15/Au_ONCV_PBE-1.2.upf
-    upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
+    # upf_sg15['au'] = load_node('2c467668-2f38-4a8c-8b57-69d67a3fb2a4')
     # sg15/Si_ONCV_PBE-1.2.upf
-    upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
+    upf_sg15['si'] = load_node('39e55083-3fc7-4405-8b3b-54a2c940dc67')
 
     for element, upf in upf_sg15.items():
         dual = 4.0

--- a/examples/example_pressure.py
+++ b/examples/example_pressure.py
@@ -49,9 +49,9 @@ if __name__ == '__main__':
 
     upf_sg15 = {}
     # # sg15/Au_ONCV_PBE-1.2.upf
-    upf_sg15['au'] = load_node('62e411c5-b0ab-4d08-875c-6fa4f74eb74e')
+    # upf_sg15['au'] = load_node('2c467668-2f38-4a8c-8b57-69d67a3fb2a4')
     # sg15/Si_ONCV_PBE-1.2.upf
-    upf_sg15['si'] = load_node('98f04e42-6da8-4960-acfa-0161e0e339a5')
+    upf_sg15['si'] = load_node('39e55083-3fc7-4405-8b3b-54a2c940dc67')
 
     for element, upf in upf_sg15.items():
         dual = 4.0

--- a/examples/example_verification.py
+++ b/examples/example_verification.py
@@ -12,6 +12,7 @@ VerificationWorkChain = WorkflowFactory('sssp_workflow.verification')
 def run_test(pw_code, ph_code, upf, dual):
     ecutwfc = np.array(
         [30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 90, 100, 120, 150, 200])
+    ecutwfc = np.array([30, 35, 40, 45, 50, 55, 200])
     ecutrho = ecutwfc * dual
     PARA_ECUTWFC_LIST = orm.List(list=list(ecutwfc))
     PARA_ECUTRHO_LIST = orm.List(list=list(ecutrho))


### PR DESCRIPTION
fix #30, steps `validate_structure` of all convergence workflow and
similar structure/pw_parameters/pseudos step of delta factor workflow is
generalized it `workflow/helper:get_pw_inputs_from_pseudo`.
Notice that the structure generated in delta factor workflow NOT the
primitive(primitive is default) one.